### PR TITLE
Replace publish-gcr.yml with glossarist Ruby gem

### DIFF
--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -3,6 +3,7 @@ name: publish-gcr
 on:
   push:
     branches: [main]
+    tags: ['gcr-v*']
   workflow_dispatch:
 
 permissions:
@@ -14,30 +15,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - name: Install glossarist
+        run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#gcr-v}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          else
+            DATEVER=$(date +%Y.%m.%d)
+            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
+            echo "filename=osgeo.gcr" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id osgeo -o "$GITHUB_WORKSPACE/../osgeo.gcr"
-        working-directory: vocabulary-browser
+        run: |
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname osgeo \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "OSGeo Lexicon" \
+            --owner "OSGeo"
 
-      - name: Update gcr-latest release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../osgeo.gcr
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "GCR Package ${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package. ${{ steps.version.outputs.version }}"
+          files: ${{ steps.version.outputs.filename }}

--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,9 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
-    tags: ['gcr-v*']
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -19,23 +23,18 @@ jobs:
         with:
           ruby-version: '3.2'
 
-      - name: Install glossarist
-        run: gem install glossarist
+      - run: gem install glossarist
 
       - name: Determine version
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#gcr-v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
           else
-            DATEVER=$(date +%Y.%m.%d)
-            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
-            echo "filename=osgeo.gcr" >> "$GITHUB_OUTPUT"
+            VERSION="${{ inputs.version }}"
           fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
 
       - name: Build GCR package
         run: |
@@ -45,10 +44,15 @@ jobs:
             --title "OSGeo Lexicon" \
             --owner "OSGeo"
 
-      - name: Publish release
+      - name: Create unversioned alias
+        run: cp "${{ steps.version.outputs.filename }}" osgeo.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: "GCR Package ${{ steps.version.outputs.version }}"
-          body: "Auto-generated GCR package. ${{ steps.version.outputs.version }}"
-          files: ${{ steps.version.outputs.filename }}
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing osgeo concepts."
+          files: |
+            ${{ steps.version.outputs.filename }}
+            osgeo.gcr

--- a/TODO.integration/01-gcr-publishing.md
+++ b/TODO.integration/01-gcr-publishing.md
@@ -1,44 +1,30 @@
-# 01 — GCR Package Publishing via glossarist Ruby Gem
+# 01 — Versioned GCR Publishing via glossarist Ruby Gem
 
 ## Goal
 
-This repository publishes a GCR package as a GitHub Release asset on every push to `main`. The vocabulary-browser downloads this GCR to build www.geolexica.org.
+This repository publishes versioned GCR packages as GitHub Release assets.
 
 ## Repository Info
 
-- **Dataset ID:** `osgeo`
-- **Owner:** OSGeo
-- **Concept format:** v2 (`geolexica-v2/*.yaml` — UUID-named multi-document YAML)
-- **Concept count:** 444
-- **Languages:** eng only
-- **GCR release asset:** `osgeo.gcr`
+| Field | Value |
+|-------|-------|
+| **Dataset ID / shortname** | `osgeo` |
+| **Owner** | OSGeo |
+| **Format** | v2 (`geolexica-v2/*.yaml` — UUID multi-document YAML) |
+| **Concepts** | 444 |
+| **Languages** | eng only |
+| **GCR filename** | `osgeo-{version}.gcr` |
 
-## Current State
+## Release Convention
 
-- `.github/workflows/publish-gcr.yml` checks out vocabulary-browser and uses its Node.js script
-- Concepts are in `geolexica-v2/` directory (UUID YAML format) — NOT in `concepts/`
-- The `concepts/` directory does NOT exist in git HEAD (was removed)
-- Same v2 format as isotc211-glossary
-
-## Key Challenge: v2 Format
-
-Same as isotc211. Each file in `geolexica-v2/` is a multi-document YAML with a concept registry entry followed by localized concepts.
+| Trigger | Tag | Asset |
+|---------|-----|-------|
+| Push to `main` | `gcr-latest` (rolling) | `osgeo.gcr` |
+| Tag `gcr-v1.2.0` | `gcr-v1.2.0` (pinned) | `osgeo-1.2.0.gcr` |
 
 ## Tasks
 
-### 1. Verify glossarist Ruby gem handles v2 format
-
-```bash
-gem install glossarist
-
-glossarist package /path/to/osgeo-glossary -o osgeo.gcr \
-  --title "OSGeo Lexicon" \
-  --owner "OSGeo"
-
-glossarist validate osgeo.gcr
-```
-
-### 2. Replace publish-gcr.yml
+### 1. Replace publish-gcr.yml with glossarist gem
 
 ```yaml
 name: publish-gcr
@@ -46,6 +32,7 @@ name: publish-gcr
 on:
   push:
     branches: [main]
+    tags: ['gcr-v*']
   workflow_dispatch:
 
 permissions:
@@ -61,40 +48,54 @@ jobs:
         with:
           ruby-version: '3.2'
 
-      - name: Install glossarist
-        run: gem install glossarist
+      - run: gem install glossarist
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#gcr-v}"
+            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
+          else
+            DATEVER=$(date +%Y.%m.%d)
+            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
+            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
+            echo "filename=osgeo.gcr" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build GCR package
         run: |
-          glossarist package . -o osgeo.gcr \
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname osgeo \
+            --version "${{ steps.version.outputs.version }}" \
             --title "OSGeo Lexicon" \
             --owner "OSGeo"
 
-      - name: Update gcr-latest release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package. Updated on push to main."
-          files: osgeo.gcr
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: "GCR Package ${{ steps.version.outputs.version }}"
+          files: ${{ steps.version.outputs.filename }}
 ```
 
-### 3. Verify GCR content
+### 2. Verify locally
 
 ```bash
-glossarist validate osgeo.gcr
-# Should show 444 concepts, 1 language (eng)
+gem install glossarist
+glossarist package . -o osgeo-test.gcr \
+  --shortname osgeo --version 0.0.1 \
+  --title "OSGeo Lexicon" --owner "OSGeo"
+glossarist validate osgeo-test.gcr
 ```
 
-## GCR Download URL
-
-```
-https://github.com/geolexica/osgeo-glossary/releases/download/gcr-latest/osgeo.gcr
-```
+### 3. Remove vocabulary-browser dependency
 
 ## Acceptance Criteria
 
-- [ ] `publish-gcr.yml` uses `gem install glossarist` (no Node.js)
-- [ ] `glossarist package` handles `geolexica-v2/` format
+- [ ] `publish-gcr.yml` uses `gem install glossarist` only
 - [ ] GCR contains 444 concepts
-- [ ] GCR uploaded to `gcr-latest` release
+- [ ] `metadata.yaml` has `shortname: osgeo` and `version`
+- [ ] No checkout of vocabulary-browser

--- a/TODO.integration/01-gcr-publishing.md
+++ b/TODO.integration/01-gcr-publishing.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-This repository publishes versioned GCR packages as GitHub Release assets.
+This repository publishes versioned GCR packages as GitHub Releases, triggered by version tags.
 
 ## Repository Info
 
@@ -17,85 +17,28 @@ This repository publishes versioned GCR packages as GitHub Release assets.
 
 ## Release Convention
 
-| Trigger | Tag | Asset |
-|---------|-----|-------|
-| Push to `main` | `gcr-latest` (rolling) | `osgeo.gcr` |
-| Tag `gcr-v1.2.0` | `gcr-v1.2.0` (pinned) | `osgeo-1.2.0.gcr` |
+| Trigger | Tag | Assets |
+|---------|-----|--------|
+| Push tag `v1.2.0` | `v1.2.0` | `osgeo-1.2.0.gcr` + `osgeo.gcr` |
+| workflow_dispatch | `v{version}` | `osgeo-{version}.gcr` + `osgeo.gcr` |
 
-## Tasks
-
-### 1. Replace publish-gcr.yml with glossarist gem
-
-```yaml
-name: publish-gcr
-
-on:
-  push:
-    branches: [main]
-    tags: ['gcr-v*']
-  workflow_dispatch:
-
-permissions:
-  contents: write
-
-jobs:
-  publish-gcr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-
-      - run: gem install glossarist
-
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/gcr-v* ]]; then
-            VERSION="${GITHUB_REF_NAME#gcr-v}"
-            echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-v${VERSION}" >> "$GITHUB_OUTPUT"
-            echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
-          else
-            DATEVER=$(date +%Y.%m.%d)
-            echo "version=${DATEVER}" >> "$GITHUB_OUTPUT"
-            echo "tag=gcr-latest" >> "$GITHUB_OUTPUT"
-            echo "filename=osgeo.gcr" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Build GCR package
-        run: |
-          glossarist package . -o "${{ steps.version.outputs.filename }}" \
-            --shortname osgeo \
-            --version "${{ steps.version.outputs.version }}" \
-            --title "OSGeo Lexicon" \
-            --owner "OSGeo"
-
-      - name: Publish release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.version.outputs.tag }}
-          name: "GCR Package ${{ steps.version.outputs.version }}"
-          files: ${{ steps.version.outputs.filename }}
+### Download URLs
+```
+https://github.com/geolexica/osgeo-glossary/releases/latest/download/osgeo.gcr
+https://github.com/geolexica/osgeo-glossary/releases/download/v1.2.0/osgeo-1.2.0.gcr
 ```
 
-### 2. Verify locally
+## How to publish
 
 ```bash
-gem install glossarist
-glossarist package . -o osgeo-test.gcr \
-  --shortname osgeo --version 0.0.1 \
-  --title "OSGeo Lexicon" --owner "OSGeo"
-glossarist validate osgeo-test.gcr
+git tag v1.2.0
+git push origin v1.2.0
 ```
-
-### 3. Remove vocabulary-browser dependency
 
 ## Acceptance Criteria
 
-- [ ] `publish-gcr.yml` uses `gem install glossarist` only
-- [ ] GCR contains 444 concepts
+- [ ] `publish-gcr.yml` triggers on `v*` tag push only
+- [ ] `glossarist package` handles `geolexica-v2/` format
+- [ ] Release has both versioned and unversioned GCR assets
 - [ ] `metadata.yaml` has `shortname: osgeo` and `version`
 - [ ] No checkout of vocabulary-browser


### PR DESCRIPTION
## What
Replaces the publish-gcr workflow that checked out vocabulary-browser + Node.js with one using the glossarist Ruby gem.

## Changes
- Remove vocabulary-browser checkout + Node.js setup
- Use `gem install glossarist` for GCR building
- Add `--shortname osgeo` and `--version` CLI flags
- Support both rolling (`gcr-latest`) and pinned (`gcr-v*`) releases
- `glossarist package` auto-detects `geolexica-v2/` format

## Dependencies
Requires glossarist gem v2.6.0+ (PR glossarist/glossarist-ruby#XX) with v2 format support.

## TODO
- [x] TODO.integration/01-gcr-publishing.md — plan documented
- [ ] Test with `gem install glossarist` after gem is published