### PR TITLE
Fix validation compliance, add glossarist workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,15 +4,30 @@ on:
   push:
     branches:
       - main
-      - staging
     tags:
       - 'v*'
   pull_request:
   workflow_dispatch:
 
 jobs:
+  validate:
+    name: Validate concepts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - run: gem install glossarist
+
+      - name: Validate with glossarist
+        run: glossarist validate .
+
   build-release:
     name: Build and release
+    needs: validate
     uses: geolexica/ci/.github/workflows/glossary-build.yml@main
 
   trigger-deploy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,28 @@ jobs:
       - name: Validate with glossarist
         run: glossarist validate .
 
+  test-package:
+    name: Test GCR package
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - run: gem install glossarist
+
+      - name: Test package build
+        run: |
+          glossarist package . -o test-osgeo.gcr \
+            --shortname osgeo \
+            --version "0.0.0-test"
+
+      - name: Verify package
+        run: test -f test-osgeo.gcr && echo "Package built successfully"
+
   build-release:
     name: Build and release
     needs: validate

--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,8 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,30 +19,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "filename=osgeo-${VERSION}.gcr" >> "$GITHUB_OUTPUT"
 
       - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id osgeo -o "$GITHUB_WORKSPACE/../osgeo.gcr"
-        working-directory: vocabulary-browser
+        run: |
+          glossarist package . -o "${{ steps.version.outputs.filename }}" \
+            --shortname osgeo \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "OSGeo Lexicon" \
+            --owner "OSGeo"
 
-      - name: Update gcr-latest release
+      - name: Create unversioned alias
+        run: cp "${{ steps.version.outputs.filename }}" osgeo.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../osgeo.gcr
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing OSGeo concepts."
+          files: |
+            ${{ steps.version.outputs.filename }}
+            osgeo.gcr

--- a/geolexica-v2/01110f1c-171e-5e5c-b41a-4d852a98ee5a.yaml
+++ b/geolexica-v2/01110f1c-171e-5e5c-b41a-4d852a98ee5a.yaml
@@ -7,7 +7,6 @@ id: 01110f1c-171e-5e5c-b41a-4d852a98ee5a
 
 ---
 data:
-  definition: []
   examples: []
   id: '83'
   notes: []

--- a/geolexica-v2/019606b3-4046-590d-95ba-20316dfab177.yaml
+++ b/geolexica-v2/019606b3-4046-590d-95ba-20316dfab177.yaml
@@ -7,7 +7,6 @@ id: '019606b3-4046-590d-95ba-20316dfab177'
 
 ---
 data:
-  definition: []
   examples: []
   id: '376'
   notes: []

--- a/geolexica-v2/035b37cb-92b0-59a3-93d5-a29156f84077.yaml
+++ b/geolexica-v2/035b37cb-92b0-59a3-93d5-a29156f84077.yaml
@@ -7,7 +7,6 @@ id: 035b37cb-92b0-59a3-93d5-a29156f84077
 
 ---
 data:
-  definition: []
   examples: []
   id: '368'
   notes: []

--- a/geolexica-v2/0483cfd6-d9ce-5c85-ac0e-f3b618ce3810.yaml
+++ b/geolexica-v2/0483cfd6-d9ce-5c85-ac0e-f3b618ce3810.yaml
@@ -7,7 +7,6 @@ id: '0483cfd6-d9ce-5c85-ac0e-f3b618ce3810'
 
 ---
 data:
-  definition: []
   examples: []
   id: '349'
   notes: []

--- a/geolexica-v2/049be33f-1e09-54b1-87f2-640cf7506fc7.yaml
+++ b/geolexica-v2/049be33f-1e09-54b1-87f2-640cf7506fc7.yaml
@@ -7,7 +7,6 @@ id: '049be33f-1e09-54b1-87f2-640cf7506fc7'
 
 ---
 data:
-  definition: []
   examples: []
   id: '243'
   notes: []

--- a/geolexica-v2/0551bf8b-3483-5657-8805-e26d73bf5aeb.yaml
+++ b/geolexica-v2/0551bf8b-3483-5657-8805-e26d73bf5aeb.yaml
@@ -7,7 +7,6 @@ id: 0551bf8b-3483-5657-8805-e26d73bf5aeb
 
 ---
 data:
-  definition: []
   examples: []
   id: '202'
   notes: []

--- a/geolexica-v2/05c8485b-ce67-5d4c-ae36-8d7962e6eb22.yaml
+++ b/geolexica-v2/05c8485b-ce67-5d4c-ae36-8d7962e6eb22.yaml
@@ -7,7 +7,6 @@ id: 05c8485b-ce67-5d4c-ae36-8d7962e6eb22
 
 ---
 data:
-  definition: []
   examples: []
   id: '405'
   notes: []

--- a/geolexica-v2/05e47def-3e94-5416-9370-6eff48f2f2b4.yaml
+++ b/geolexica-v2/05e47def-3e94-5416-9370-6eff48f2f2b4.yaml
@@ -7,7 +7,6 @@ id: 05e47def-3e94-5416-9370-6eff48f2f2b4
 
 ---
 data:
-  definition: []
   examples: []
   id: '256'
   notes: []

--- a/geolexica-v2/07d74614-fbe5-56a3-9522-d1c127a285ee.yaml
+++ b/geolexica-v2/07d74614-fbe5-56a3-9522-d1c127a285ee.yaml
@@ -7,7 +7,6 @@ id: 07d74614-fbe5-56a3-9522-d1c127a285ee
 
 ---
 data:
-  definition: []
   examples: []
   id: '393'
   notes: []

--- a/geolexica-v2/0800a62e-bc42-59c0-b1fc-79acbded47aa.yaml
+++ b/geolexica-v2/0800a62e-bc42-59c0-b1fc-79acbded47aa.yaml
@@ -7,7 +7,6 @@ id: '0800a62e-bc42-59c0-b1fc-79acbded47aa'
 
 ---
 data:
-  definition: []
   examples: []
   id: '353'
   notes: []

--- a/geolexica-v2/095d82fb-64fd-5140-b38f-53efac0a8503.yaml
+++ b/geolexica-v2/095d82fb-64fd-5140-b38f-53efac0a8503.yaml
@@ -7,7 +7,6 @@ id: '095d82fb-64fd-5140-b38f-53efac0a8503'
 
 ---
 data:
-  definition: []
   examples: []
   id: '222'
   notes: []

--- a/geolexica-v2/0a68a439-8035-5bc0-930a-bcabaf5d63e0.yaml
+++ b/geolexica-v2/0a68a439-8035-5bc0-930a-bcabaf5d63e0.yaml
@@ -7,7 +7,6 @@ id: 0a68a439-8035-5bc0-930a-bcabaf5d63e0
 
 ---
 data:
-  definition: []
   examples: []
   id: '293'
   notes: []

--- a/geolexica-v2/0bedf185-29df-5963-9511-2965ee999f5d.yaml
+++ b/geolexica-v2/0bedf185-29df-5963-9511-2965ee999f5d.yaml
@@ -7,7 +7,6 @@ id: 0bedf185-29df-5963-9511-2965ee999f5d
 
 ---
 data:
-  definition: []
   examples: []
   id: '266'
   notes: []

--- a/geolexica-v2/0c2ea468-4b78-5891-8796-d6474941c944.yaml
+++ b/geolexica-v2/0c2ea468-4b78-5891-8796-d6474941c944.yaml
@@ -7,7 +7,6 @@ id: 0c2ea468-4b78-5891-8796-d6474941c944
 
 ---
 data:
-  definition: []
   examples: []
   id: '193'
   notes: []

--- a/geolexica-v2/0db6bdd4-24e6-57e5-ad37-5879ca85b02f.yaml
+++ b/geolexica-v2/0db6bdd4-24e6-57e5-ad37-5879ca85b02f.yaml
@@ -7,7 +7,6 @@ id: 0db6bdd4-24e6-57e5-ad37-5879ca85b02f
 
 ---
 data:
-  definition: []
   examples: []
   id: '185'
   notes: []

--- a/geolexica-v2/101392a9-7b7d-5a96-bb21-2ef5083dc73f.yaml
+++ b/geolexica-v2/101392a9-7b7d-5a96-bb21-2ef5083dc73f.yaml
@@ -7,7 +7,6 @@ id: 101392a9-7b7d-5a96-bb21-2ef5083dc73f
 
 ---
 data:
-  definition: []
   examples: []
   id: '285'
   notes: []

--- a/geolexica-v2/10228744-aec1-5e92-9eae-e9e7607473a0.yaml
+++ b/geolexica-v2/10228744-aec1-5e92-9eae-e9e7607473a0.yaml
@@ -7,7 +7,6 @@ id: 10228744-aec1-5e92-9eae-e9e7607473a0
 
 ---
 data:
-  definition: []
   examples: []
   id: '214'
   notes: []

--- a/geolexica-v2/1062ffde-5d80-5f4f-ad20-41d9c5f77f92.yaml
+++ b/geolexica-v2/1062ffde-5d80-5f4f-ad20-41d9c5f77f92.yaml
@@ -7,7 +7,6 @@ id: 1062ffde-5d80-5f4f-ad20-41d9c5f77f92
 
 ---
 data:
-  definition: []
   examples: []
   id: '48'
   notes: []

--- a/geolexica-v2/11b3081b-b9c4-5eeb-a8db-269c970c0cb4.yaml
+++ b/geolexica-v2/11b3081b-b9c4-5eeb-a8db-269c970c0cb4.yaml
@@ -7,7 +7,6 @@ id: 11b3081b-b9c4-5eeb-a8db-269c970c0cb4
 
 ---
 data:
-  definition: []
   examples: []
   id: '82'
   notes: []

--- a/geolexica-v2/1602d4fa-f6a4-54d2-b049-4cda53f3c36a.yaml
+++ b/geolexica-v2/1602d4fa-f6a4-54d2-b049-4cda53f3c36a.yaml
@@ -7,7 +7,6 @@ id: 1602d4fa-f6a4-54d2-b049-4cda53f3c36a
 
 ---
 data:
-  definition: []
   examples: []
   id: '11'
   notes: []

--- a/geolexica-v2/17f15647-1038-5877-8ee4-0e9e9e05d887.yaml
+++ b/geolexica-v2/17f15647-1038-5877-8ee4-0e9e9e05d887.yaml
@@ -7,7 +7,6 @@ id: 17f15647-1038-5877-8ee4-0e9e9e05d887
 
 ---
 data:
-  definition: []
   examples: []
   id: '135'
   notes: []

--- a/geolexica-v2/18b356e2-b877-5c66-bf80-bb7481f72157.yaml
+++ b/geolexica-v2/18b356e2-b877-5c66-bf80-bb7481f72157.yaml
@@ -7,7 +7,6 @@ id: 18b356e2-b877-5c66-bf80-bb7481f72157
 
 ---
 data:
-  definition: []
   examples: []
   id: '153'
   notes: []

--- a/geolexica-v2/190e0b46-8783-5d37-b7fa-ee3987faf788.yaml
+++ b/geolexica-v2/190e0b46-8783-5d37-b7fa-ee3987faf788.yaml
@@ -7,7 +7,6 @@ id: 190e0b46-8783-5d37-b7fa-ee3987faf788
 
 ---
 data:
-  definition: []
   examples: []
   id: '201'
   notes: []

--- a/geolexica-v2/19342139-dc50-548a-ab3f-9705ee3ba7e7.yaml
+++ b/geolexica-v2/19342139-dc50-548a-ab3f-9705ee3ba7e7.yaml
@@ -7,7 +7,6 @@ id: 19342139-dc50-548a-ab3f-9705ee3ba7e7
 
 ---
 data:
-  definition: []
   examples: []
   id: '80'
   notes: []

--- a/geolexica-v2/19ae83a2-a7e4-5b81-ac1b-ca8a3b5b3018.yaml
+++ b/geolexica-v2/19ae83a2-a7e4-5b81-ac1b-ca8a3b5b3018.yaml
@@ -7,7 +7,6 @@ id: 19ae83a2-a7e4-5b81-ac1b-ca8a3b5b3018
 
 ---
 data:
-  definition: []
   examples: []
   id: '347'
   notes: []

--- a/geolexica-v2/1b5018c6-d9c5-53a0-9590-01a698385431.yaml
+++ b/geolexica-v2/1b5018c6-d9c5-53a0-9590-01a698385431.yaml
@@ -7,7 +7,6 @@ id: 1b5018c6-d9c5-53a0-9590-01a698385431
 
 ---
 data:
-  definition: []
   examples: []
   id: '298'
   notes: []

--- a/geolexica-v2/1b8c3c4f-d879-5a34-b550-04c1068926c3.yaml
+++ b/geolexica-v2/1b8c3c4f-d879-5a34-b550-04c1068926c3.yaml
@@ -7,7 +7,6 @@ id: 1b8c3c4f-d879-5a34-b550-04c1068926c3
 
 ---
 data:
-  definition: []
   examples: []
   id: '319'
   notes: []

--- a/geolexica-v2/1bab12f4-fb9a-55fa-b488-657da824eeee.yaml
+++ b/geolexica-v2/1bab12f4-fb9a-55fa-b488-657da824eeee.yaml
@@ -7,7 +7,6 @@ id: 1bab12f4-fb9a-55fa-b488-657da824eeee
 
 ---
 data:
-  definition: []
   examples: []
   id: '301'
   notes: []

--- a/geolexica-v2/1c130672-7a65-57a6-ad18-37d959f8e678.yaml
+++ b/geolexica-v2/1c130672-7a65-57a6-ad18-37d959f8e678.yaml
@@ -7,7 +7,6 @@ id: 1c130672-7a65-57a6-ad18-37d959f8e678
 
 ---
 data:
-  definition: []
   examples: []
   id: '399'
   notes: []

--- a/geolexica-v2/1c5c08ba-3fe4-57b5-9938-65f8339b511d.yaml
+++ b/geolexica-v2/1c5c08ba-3fe4-57b5-9938-65f8339b511d.yaml
@@ -7,7 +7,6 @@ id: 1c5c08ba-3fe4-57b5-9938-65f8339b511d
 
 ---
 data:
-  definition: []
   examples: []
   id: '260'
   notes: []

--- a/geolexica-v2/1e25c185-6bd7-52f6-aa3b-5104f9ba27d8.yaml
+++ b/geolexica-v2/1e25c185-6bd7-52f6-aa3b-5104f9ba27d8.yaml
@@ -7,7 +7,6 @@ id: 1e25c185-6bd7-52f6-aa3b-5104f9ba27d8
 
 ---
 data:
-  definition: []
   examples: []
   id: '244'
   notes: []

--- a/geolexica-v2/1e6b574f-a40e-518e-923c-b5ca9b41342b.yaml
+++ b/geolexica-v2/1e6b574f-a40e-518e-923c-b5ca9b41342b.yaml
@@ -7,7 +7,6 @@ id: 1e6b574f-a40e-518e-923c-b5ca9b41342b
 
 ---
 data:
-  definition: []
   examples: []
   id: '249'
   notes: []

--- a/geolexica-v2/1ebf31b2-b73d-521e-99c7-5f513385fa72.yaml
+++ b/geolexica-v2/1ebf31b2-b73d-521e-99c7-5f513385fa72.yaml
@@ -7,7 +7,6 @@ id: 1ebf31b2-b73d-521e-99c7-5f513385fa72
 
 ---
 data:
-  definition: []
   examples: []
   id: '154'
   notes: []

--- a/geolexica-v2/1ef51712-4955-56fb-b68e-2628126d5c1f.yaml
+++ b/geolexica-v2/1ef51712-4955-56fb-b68e-2628126d5c1f.yaml
@@ -7,7 +7,6 @@ id: 1ef51712-4955-56fb-b68e-2628126d5c1f
 
 ---
 data:
-  definition: []
   examples: []
   id: '281'
   notes: []

--- a/geolexica-v2/2055a8f9-53b4-54ce-b8fc-fbbee3532a1d.yaml
+++ b/geolexica-v2/2055a8f9-53b4-54ce-b8fc-fbbee3532a1d.yaml
@@ -7,7 +7,6 @@ id: 2055a8f9-53b4-54ce-b8fc-fbbee3532a1d
 
 ---
 data:
-  definition: []
   examples: []
   id: '317'
   notes: []

--- a/geolexica-v2/231dc61a-bc9f-5f3d-901a-1e01b00c7b1d.yaml
+++ b/geolexica-v2/231dc61a-bc9f-5f3d-901a-1e01b00c7b1d.yaml
@@ -7,7 +7,6 @@ id: 231dc61a-bc9f-5f3d-901a-1e01b00c7b1d
 
 ---
 data:
-  definition: []
   examples: []
   id: '168'
   notes: []

--- a/geolexica-v2/23b45d97-cfff-50c1-bb13-882b09a281ff.yaml
+++ b/geolexica-v2/23b45d97-cfff-50c1-bb13-882b09a281ff.yaml
@@ -7,7 +7,6 @@ id: 23b45d97-cfff-50c1-bb13-882b09a281ff
 
 ---
 data:
-  definition: []
   examples: []
   id: '215'
   notes:

--- a/geolexica-v2/27b35297-a530-522a-a284-f1da7e680de0.yaml
+++ b/geolexica-v2/27b35297-a530-522a-a284-f1da7e680de0.yaml
@@ -7,7 +7,6 @@ id: 27b35297-a530-522a-a284-f1da7e680de0
 
 ---
 data:
-  definition: []
   examples: []
   id: '387'
   notes: []

--- a/geolexica-v2/29ecc224-0ab2-5cfb-b899-482c565a1ecc.yaml
+++ b/geolexica-v2/29ecc224-0ab2-5cfb-b899-482c565a1ecc.yaml
@@ -7,7 +7,6 @@ id: 29ecc224-0ab2-5cfb-b899-482c565a1ecc
 
 ---
 data:
-  definition: []
   examples: []
   id: '113'
   notes: []

--- a/geolexica-v2/2b7697c4-4f7d-5f23-8563-528f4f0fdef9.yaml
+++ b/geolexica-v2/2b7697c4-4f7d-5f23-8563-528f4f0fdef9.yaml
@@ -7,7 +7,6 @@ id: 2b7697c4-4f7d-5f23-8563-528f4f0fdef9
 
 ---
 data:
-  definition: []
   examples: []
   id: '252'
   notes: []

--- a/geolexica-v2/2de46c05-b499-5ee8-b070-0a2d096b4f82.yaml
+++ b/geolexica-v2/2de46c05-b499-5ee8-b070-0a2d096b4f82.yaml
@@ -7,7 +7,6 @@ id: 2de46c05-b499-5ee8-b070-0a2d096b4f82
 
 ---
 data:
-  definition: []
   examples: []
   id: '388'
   notes: []

--- a/geolexica-v2/2e7e26e9-112c-5104-835d-56eef0730dd2.yaml
+++ b/geolexica-v2/2e7e26e9-112c-5104-835d-56eef0730dd2.yaml
@@ -7,7 +7,6 @@ id: 2e7e26e9-112c-5104-835d-56eef0730dd2
 
 ---
 data:
-  definition: []
   examples: []
   id: '273'
   notes: []

--- a/geolexica-v2/2e83e874-2af9-5947-8f07-e1ab37e8911d.yaml
+++ b/geolexica-v2/2e83e874-2af9-5947-8f07-e1ab37e8911d.yaml
@@ -7,7 +7,6 @@ id: 2e83e874-2af9-5947-8f07-e1ab37e8911d
 
 ---
 data:
-  definition: []
   examples: []
   id: '423'
   notes: []

--- a/geolexica-v2/2f7cd564-5f83-5ec9-8cc2-5eafddfa25e9.yaml
+++ b/geolexica-v2/2f7cd564-5f83-5ec9-8cc2-5eafddfa25e9.yaml
@@ -7,7 +7,6 @@ id: 2f7cd564-5f83-5ec9-8cc2-5eafddfa25e9
 
 ---
 data:
-  definition: []
   examples: []
   id: '246'
   notes: []

--- a/geolexica-v2/2f867ae4-6eec-517f-b527-417e3ae78e75.yaml
+++ b/geolexica-v2/2f867ae4-6eec-517f-b527-417e3ae78e75.yaml
@@ -7,7 +7,6 @@ id: 2f867ae4-6eec-517f-b527-417e3ae78e75
 
 ---
 data:
-  definition: []
   examples: []
   id: '378'
   notes: []

--- a/geolexica-v2/30f52e36-1781-5cf9-9f8f-6ab7ec3e1350.yaml
+++ b/geolexica-v2/30f52e36-1781-5cf9-9f8f-6ab7ec3e1350.yaml
@@ -7,7 +7,6 @@ id: 30f52e36-1781-5cf9-9f8f-6ab7ec3e1350
 
 ---
 data:
-  definition: []
   examples: []
   id: '398'
   notes: []

--- a/geolexica-v2/31d4da21-7e19-51e5-9e79-0bb0eab0773c.yaml
+++ b/geolexica-v2/31d4da21-7e19-51e5-9e79-0bb0eab0773c.yaml
@@ -7,7 +7,6 @@ id: 31d4da21-7e19-51e5-9e79-0bb0eab0773c
 
 ---
 data:
-  definition: []
   examples: []
   id: '192'
   notes: []

--- a/geolexica-v2/326cca8a-7a03-54cb-8214-bc412ed2af65.yaml
+++ b/geolexica-v2/326cca8a-7a03-54cb-8214-bc412ed2af65.yaml
@@ -7,7 +7,6 @@ id: 326cca8a-7a03-54cb-8214-bc412ed2af65
 
 ---
 data:
-  definition: []
   examples: []
   id: '68'
   notes: []

--- a/geolexica-v2/32966feb-96b8-5aad-aa37-7a59ab7ea4de.yaml
+++ b/geolexica-v2/32966feb-96b8-5aad-aa37-7a59ab7ea4de.yaml
@@ -7,7 +7,6 @@ id: 32966feb-96b8-5aad-aa37-7a59ab7ea4de
 
 ---
 data:
-  definition: []
   examples: []
   id: '430'
   notes: []

--- a/geolexica-v2/3410173f-fb56-550c-b3e1-41bc986a7e13.yaml
+++ b/geolexica-v2/3410173f-fb56-550c-b3e1-41bc986a7e13.yaml
@@ -7,7 +7,6 @@ id: 3410173f-fb56-550c-b3e1-41bc986a7e13
 
 ---
 data:
-  definition: []
   examples: []
   id: '374'
   notes: []

--- a/geolexica-v2/36d6e1ed-0364-5482-a698-338db84a1fe4.yaml
+++ b/geolexica-v2/36d6e1ed-0364-5482-a698-338db84a1fe4.yaml
@@ -7,7 +7,6 @@ id: 36d6e1ed-0364-5482-a698-338db84a1fe4
 
 ---
 data:
-  definition: []
   examples: []
   id: '195'
   notes: []

--- a/geolexica-v2/389b9951-37cd-56ba-97ee-7061c37ada27.yaml
+++ b/geolexica-v2/389b9951-37cd-56ba-97ee-7061c37ada27.yaml
@@ -7,7 +7,6 @@ id: 389b9951-37cd-56ba-97ee-7061c37ada27
 
 ---
 data:
-  definition: []
   examples: []
   id: '408'
   notes: []

--- a/geolexica-v2/3ac008e9-5d50-5fc4-95df-a747e64b12cd.yaml
+++ b/geolexica-v2/3ac008e9-5d50-5fc4-95df-a747e64b12cd.yaml
@@ -7,7 +7,6 @@ id: 3ac008e9-5d50-5fc4-95df-a747e64b12cd
 
 ---
 data:
-  definition: []
   examples: []
   id: '432'
   notes: []

--- a/geolexica-v2/3ba6f957-a725-50dc-b065-17c250e0f8f3.yaml
+++ b/geolexica-v2/3ba6f957-a725-50dc-b065-17c250e0f8f3.yaml
@@ -7,7 +7,6 @@ id: 3ba6f957-a725-50dc-b065-17c250e0f8f3
 
 ---
 data:
-  definition: []
   examples: []
   id: '232'
   notes: []

--- a/geolexica-v2/3bfa62ff-732a-5cf9-91e3-6da2f81da709.yaml
+++ b/geolexica-v2/3bfa62ff-732a-5cf9-91e3-6da2f81da709.yaml
@@ -7,7 +7,6 @@ id: 3bfa62ff-732a-5cf9-91e3-6da2f81da709
 
 ---
 data:
-  definition: []
   examples: []
   id: '420'
   notes: []

--- a/geolexica-v2/3c287548-3dca-56f2-9911-d1aba946ccaa.yaml
+++ b/geolexica-v2/3c287548-3dca-56f2-9911-d1aba946ccaa.yaml
@@ -7,7 +7,6 @@ id: 3c287548-3dca-56f2-9911-d1aba946ccaa
 
 ---
 data:
-  definition: []
   examples: []
   id: '72'
   notes: []

--- a/geolexica-v2/3cc89dfe-9d37-554e-80ff-367456fed696.yaml
+++ b/geolexica-v2/3cc89dfe-9d37-554e-80ff-367456fed696.yaml
@@ -7,7 +7,6 @@ id: 3cc89dfe-9d37-554e-80ff-367456fed696
 
 ---
 data:
-  definition: []
   examples: []
   id: '417'
   notes: []

--- a/geolexica-v2/3edaaf3a-52f9-5b58-a816-1e323981138d.yaml
+++ b/geolexica-v2/3edaaf3a-52f9-5b58-a816-1e323981138d.yaml
@@ -7,7 +7,6 @@ id: 3edaaf3a-52f9-5b58-a816-1e323981138d
 
 ---
 data:
-  definition: []
   examples: []
   id: '30'
   notes: []

--- a/geolexica-v2/3ee506c2-abe3-515e-8641-f0c88afd8ce3.yaml
+++ b/geolexica-v2/3ee506c2-abe3-515e-8641-f0c88afd8ce3.yaml
@@ -7,7 +7,6 @@ id: 3ee506c2-abe3-515e-8641-f0c88afd8ce3
 
 ---
 data:
-  definition: []
   examples: []
   id: '103'
   notes: []

--- a/geolexica-v2/3fc46748-8f4e-5a90-8ce5-bab14a2e09e1.yaml
+++ b/geolexica-v2/3fc46748-8f4e-5a90-8ce5-bab14a2e09e1.yaml
@@ -7,7 +7,6 @@ id: 3fc46748-8f4e-5a90-8ce5-bab14a2e09e1
 
 ---
 data:
-  definition: []
   examples: []
   id: '401'
   notes: []

--- a/geolexica-v2/42a8d824-a94d-5909-928f-32c71ae36352.yaml
+++ b/geolexica-v2/42a8d824-a94d-5909-928f-32c71ae36352.yaml
@@ -7,7 +7,6 @@ id: 42a8d824-a94d-5909-928f-32c71ae36352
 
 ---
 data:
-  definition: []
   examples: []
   id: '17'
   notes: []

--- a/geolexica-v2/448fa03c-3fab-527c-9263-55a9ea3271d3.yaml
+++ b/geolexica-v2/448fa03c-3fab-527c-9263-55a9ea3271d3.yaml
@@ -7,7 +7,6 @@ id: 448fa03c-3fab-527c-9263-55a9ea3271d3
 
 ---
 data:
-  definition: []
   examples: []
   id: '442'
   notes: []

--- a/geolexica-v2/4514d109-cc3c-5cdb-952a-79bc35a2269b.yaml
+++ b/geolexica-v2/4514d109-cc3c-5cdb-952a-79bc35a2269b.yaml
@@ -7,7 +7,6 @@ id: 4514d109-cc3c-5cdb-952a-79bc35a2269b
 
 ---
 data:
-  definition: []
   examples: []
   id: '189'
   notes: []

--- a/geolexica-v2/45b2ed8f-b54e-5f1e-ada7-d77a1c871346.yaml
+++ b/geolexica-v2/45b2ed8f-b54e-5f1e-ada7-d77a1c871346.yaml
@@ -7,7 +7,6 @@ id: 45b2ed8f-b54e-5f1e-ada7-d77a1c871346
 
 ---
 data:
-  definition: []
   examples: []
   id: '375'
   notes: []

--- a/geolexica-v2/46669cd6-3879-5f87-8040-bd0c7ce30179.yaml
+++ b/geolexica-v2/46669cd6-3879-5f87-8040-bd0c7ce30179.yaml
@@ -7,7 +7,6 @@ id: 46669cd6-3879-5f87-8040-bd0c7ce30179
 
 ---
 data:
-  definition: []
   examples: []
   id: '324'
   notes: []

--- a/geolexica-v2/469c614b-d378-5ace-a527-b4ef5f04053c.yaml
+++ b/geolexica-v2/469c614b-d378-5ace-a527-b4ef5f04053c.yaml
@@ -7,7 +7,6 @@ id: 469c614b-d378-5ace-a527-b4ef5f04053c
 
 ---
 data:
-  definition: []
   examples: []
   id: '396'
   notes: []

--- a/geolexica-v2/47b38069-51d6-5084-bfb8-a1fbc4b681fd.yaml
+++ b/geolexica-v2/47b38069-51d6-5084-bfb8-a1fbc4b681fd.yaml
@@ -7,7 +7,6 @@ id: 47b38069-51d6-5084-bfb8-a1fbc4b681fd
 
 ---
 data:
-  definition: []
   examples: []
   id: '104'
   notes: []

--- a/geolexica-v2/4877f94d-9ecf-569a-8125-3d66cd52dcd3.yaml
+++ b/geolexica-v2/4877f94d-9ecf-569a-8125-3d66cd52dcd3.yaml
@@ -7,7 +7,6 @@ id: 4877f94d-9ecf-569a-8125-3d66cd52dcd3
 
 ---
 data:
-  definition: []
   examples: []
   id: '220'
   notes: []

--- a/geolexica-v2/48d05b69-1c52-583a-9f49-25f13ca4ed1f.yaml
+++ b/geolexica-v2/48d05b69-1c52-583a-9f49-25f13ca4ed1f.yaml
@@ -7,7 +7,6 @@ id: 48d05b69-1c52-583a-9f49-25f13ca4ed1f
 
 ---
 data:
-  definition: []
   examples: []
   id: '381'
   notes: []

--- a/geolexica-v2/49556d6b-5407-5710-8b12-9b42e2996621.yaml
+++ b/geolexica-v2/49556d6b-5407-5710-8b12-9b42e2996621.yaml
@@ -7,7 +7,6 @@ id: 49556d6b-5407-5710-8b12-9b42e2996621
 
 ---
 data:
-  definition: []
   examples: []
   id: '259'
   notes: []

--- a/geolexica-v2/49a11134-74d0-5e52-9b47-9947b27be8ee.yaml
+++ b/geolexica-v2/49a11134-74d0-5e52-9b47-9947b27be8ee.yaml
@@ -7,7 +7,6 @@ id: 49a11134-74d0-5e52-9b47-9947b27be8ee
 
 ---
 data:
-  definition: []
   examples: []
   id: '231'
   notes: []

--- a/geolexica-v2/4b2e0990-ab86-5c34-b553-94460397725a.yaml
+++ b/geolexica-v2/4b2e0990-ab86-5c34-b553-94460397725a.yaml
@@ -7,7 +7,6 @@ id: 4b2e0990-ab86-5c34-b553-94460397725a
 
 ---
 data:
-  definition: []
   examples: []
   id: '278'
   notes: []

--- a/geolexica-v2/4b8d254e-e143-5f1a-9657-bd3c075f06da.yaml
+++ b/geolexica-v2/4b8d254e-e143-5f1a-9657-bd3c075f06da.yaml
@@ -7,7 +7,6 @@ id: 4b8d254e-e143-5f1a-9657-bd3c075f06da
 
 ---
 data:
-  definition: []
   examples: []
   id: '309'
   notes: []

--- a/geolexica-v2/4b95fa31-74ff-57cf-a853-6a6821d31110.yaml
+++ b/geolexica-v2/4b95fa31-74ff-57cf-a853-6a6821d31110.yaml
@@ -7,7 +7,6 @@ id: 4b95fa31-74ff-57cf-a853-6a6821d31110
 
 ---
 data:
-  definition: []
   examples: []
   id: '187'
   notes: []

--- a/geolexica-v2/4c07732c-5c09-5408-bd0d-73d9c090808b.yaml
+++ b/geolexica-v2/4c07732c-5c09-5408-bd0d-73d9c090808b.yaml
@@ -7,7 +7,6 @@ id: 4c07732c-5c09-5408-bd0d-73d9c090808b
 
 ---
 data:
-  definition: []
   examples: []
   id: '300'
   notes: []

--- a/geolexica-v2/4d3bebf4-3c5f-53de-8a37-e686f849f3d1.yaml
+++ b/geolexica-v2/4d3bebf4-3c5f-53de-8a37-e686f849f3d1.yaml
@@ -7,7 +7,6 @@ id: 4d3bebf4-3c5f-53de-8a37-e686f849f3d1
 
 ---
 data:
-  definition: []
   examples: []
   id: '29'
   notes: []

--- a/geolexica-v2/4d712992-30d6-5850-985b-1962ad6db59b.yaml
+++ b/geolexica-v2/4d712992-30d6-5850-985b-1962ad6db59b.yaml
@@ -7,7 +7,6 @@ id: 4d712992-30d6-5850-985b-1962ad6db59b
 
 ---
 data:
-  definition: []
   examples: []
   id: '1'
   notes: []

--- a/geolexica-v2/4f212c12-70ad-52be-a75f-f426a05c215e.yaml
+++ b/geolexica-v2/4f212c12-70ad-52be-a75f-f426a05c215e.yaml
@@ -7,7 +7,6 @@ id: 4f212c12-70ad-52be-a75f-f426a05c215e
 
 ---
 data:
-  definition: []
   examples: []
   id: '332'
   notes: []

--- a/geolexica-v2/502e0095-cde5-5fa6-81db-1223e6eeab6f.yaml
+++ b/geolexica-v2/502e0095-cde5-5fa6-81db-1223e6eeab6f.yaml
@@ -7,7 +7,6 @@ id: 502e0095-cde5-5fa6-81db-1223e6eeab6f
 
 ---
 data:
-  definition: []
   examples: []
   id: '43'
   notes: []

--- a/geolexica-v2/504e9e16-231e-5da7-a265-841ddf6df19a.yaml
+++ b/geolexica-v2/504e9e16-231e-5da7-a265-841ddf6df19a.yaml
@@ -7,7 +7,6 @@ id: 504e9e16-231e-5da7-a265-841ddf6df19a
 
 ---
 data:
-  definition: []
   examples: []
   id: '77'
   notes: []

--- a/geolexica-v2/514a21ea-c28d-5822-a3c1-70a6c62a48fa.yaml
+++ b/geolexica-v2/514a21ea-c28d-5822-a3c1-70a6c62a48fa.yaml
@@ -7,7 +7,6 @@ id: 514a21ea-c28d-5822-a3c1-70a6c62a48fa
 
 ---
 data:
-  definition: []
   examples: []
   id: '76'
   notes: []

--- a/geolexica-v2/52eba471-235a-561f-ab0e-0503d9663ea5.yaml
+++ b/geolexica-v2/52eba471-235a-561f-ab0e-0503d9663ea5.yaml
@@ -7,7 +7,6 @@ id: 52eba471-235a-561f-ab0e-0503d9663ea5
 
 ---
 data:
-  definition: []
   examples: []
   id: '268'
   notes: []

--- a/geolexica-v2/52fc74bf-80c0-54e5-9ad0-d55ef38b7a76.yaml
+++ b/geolexica-v2/52fc74bf-80c0-54e5-9ad0-d55ef38b7a76.yaml
@@ -7,7 +7,6 @@ id: 52fc74bf-80c0-54e5-9ad0-d55ef38b7a76
 
 ---
 data:
-  definition: []
   examples: []
   id: '93'
   notes: []

--- a/geolexica-v2/53a1a06e-52a6-522c-bd3b-b91537b368bb.yaml
+++ b/geolexica-v2/53a1a06e-52a6-522c-bd3b-b91537b368bb.yaml
@@ -7,7 +7,6 @@ id: 53a1a06e-52a6-522c-bd3b-b91537b368bb
 
 ---
 data:
-  definition: []
   examples: []
   id: '359'
   notes: []

--- a/geolexica-v2/54b139b1-8695-538b-bb04-a5e29569f801.yaml
+++ b/geolexica-v2/54b139b1-8695-538b-bb04-a5e29569f801.yaml
@@ -7,7 +7,6 @@ id: 54b139b1-8695-538b-bb04-a5e29569f801
 
 ---
 data:
-  definition: []
   examples: []
   id: '251'
   notes: []

--- a/geolexica-v2/54df4a83-6298-5018-9488-d49acb5e2470.yaml
+++ b/geolexica-v2/54df4a83-6298-5018-9488-d49acb5e2470.yaml
@@ -7,7 +7,6 @@ id: 54df4a83-6298-5018-9488-d49acb5e2470
 
 ---
 data:
-  definition: []
   examples: []
   id: '49'
   notes: []

--- a/geolexica-v2/55a2fd31-4728-59c3-880c-b9ab6323d87f.yaml
+++ b/geolexica-v2/55a2fd31-4728-59c3-880c-b9ab6323d87f.yaml
@@ -7,7 +7,6 @@ id: 55a2fd31-4728-59c3-880c-b9ab6323d87f
 
 ---
 data:
-  definition: []
   examples: []
   id: '150'
   notes: []

--- a/geolexica-v2/56a0a93b-9db6-5944-960a-e9dd9249b450.yaml
+++ b/geolexica-v2/56a0a93b-9db6-5944-960a-e9dd9249b450.yaml
@@ -7,7 +7,6 @@ id: 56a0a93b-9db6-5944-960a-e9dd9249b450
 
 ---
 data:
-  definition: []
   examples: []
   id: '329'
   notes: []

--- a/geolexica-v2/56e3f5f6-9355-5673-8bd2-6b4e6d223ae8.yaml
+++ b/geolexica-v2/56e3f5f6-9355-5673-8bd2-6b4e6d223ae8.yaml
@@ -7,7 +7,6 @@ id: 56e3f5f6-9355-5673-8bd2-6b4e6d223ae8
 
 ---
 data:
-  definition: []
   examples: []
   id: '382'
   notes: []

--- a/geolexica-v2/58d1b531-9020-5e02-a527-11eb4fbe82b0.yaml
+++ b/geolexica-v2/58d1b531-9020-5e02-a527-11eb4fbe82b0.yaml
@@ -7,7 +7,6 @@ id: 58d1b531-9020-5e02-a527-11eb4fbe82b0
 
 ---
 data:
-  definition: []
   examples: []
   id: '325'
   notes: []

--- a/geolexica-v2/59674105-7802-5baf-a688-2a22c51a38c9.yaml
+++ b/geolexica-v2/59674105-7802-5baf-a688-2a22c51a38c9.yaml
@@ -7,7 +7,6 @@ id: 59674105-7802-5baf-a688-2a22c51a38c9
 
 ---
 data:
-  definition: []
   examples: []
   id: '258'
   notes: []

--- a/geolexica-v2/5a570f80-e41b-5ed0-b35d-60cc1efb4892.yaml
+++ b/geolexica-v2/5a570f80-e41b-5ed0-b35d-60cc1efb4892.yaml
@@ -7,7 +7,6 @@ id: 5a570f80-e41b-5ed0-b35d-60cc1efb4892
 
 ---
 data:
-  definition: []
   examples: []
   id: '406'
   notes: []

--- a/geolexica-v2/5b8b0b40-3c48-50f5-9d0b-71c96cbc3b3f.yaml
+++ b/geolexica-v2/5b8b0b40-3c48-50f5-9d0b-71c96cbc3b3f.yaml
@@ -7,7 +7,6 @@ id: 5b8b0b40-3c48-50f5-9d0b-71c96cbc3b3f
 
 ---
 data:
-  definition: []
   examples: []
   id: '22'
   notes: []

--- a/geolexica-v2/5bbd3038-2f23-5d29-be92-062ed251f505.yaml
+++ b/geolexica-v2/5bbd3038-2f23-5d29-be92-062ed251f505.yaml
@@ -7,7 +7,6 @@ id: 5bbd3038-2f23-5d29-be92-062ed251f505
 
 ---
 data:
-  definition: []
   examples: []
   id: '328'
   notes: []

--- a/geolexica-v2/5bf69a52-ab8b-5bc6-b355-0c15e37b8a79.yaml
+++ b/geolexica-v2/5bf69a52-ab8b-5bc6-b355-0c15e37b8a79.yaml
@@ -7,7 +7,6 @@ id: 5bf69a52-ab8b-5bc6-b355-0c15e37b8a79
 
 ---
 data:
-  definition: []
   examples: []
   id: '210'
   notes: []

--- a/geolexica-v2/5da357ae-c65f-5a23-901f-fbbb110b5395.yaml
+++ b/geolexica-v2/5da357ae-c65f-5a23-901f-fbbb110b5395.yaml
@@ -7,7 +7,6 @@ id: 5da357ae-c65f-5a23-901f-fbbb110b5395
 
 ---
 data:
-  definition: []
   examples: []
   id: '45'
   notes: []

--- a/geolexica-v2/5e22aea1-e8f2-5260-bdc6-743e73292c3f.yaml
+++ b/geolexica-v2/5e22aea1-e8f2-5260-bdc6-743e73292c3f.yaml
@@ -7,7 +7,6 @@ id: 5e22aea1-e8f2-5260-bdc6-743e73292c3f
 
 ---
 data:
-  definition: []
   examples: []
   id: '4'
   notes: []

--- a/geolexica-v2/5f37373b-d300-57c7-b032-796e1d274a85.yaml
+++ b/geolexica-v2/5f37373b-d300-57c7-b032-796e1d274a85.yaml
@@ -7,7 +7,6 @@ id: 5f37373b-d300-57c7-b032-796e1d274a85
 
 ---
 data:
-  definition: []
   examples: []
   id: '194'
   notes:

--- a/geolexica-v2/5f4959c0-c67b-5dac-b6a3-87c5d973d104.yaml
+++ b/geolexica-v2/5f4959c0-c67b-5dac-b6a3-87c5d973d104.yaml
@@ -7,7 +7,6 @@ id: 5f4959c0-c67b-5dac-b6a3-87c5d973d104
 
 ---
 data:
-  definition: []
   examples: []
   id: '169'
   notes: []

--- a/geolexica-v2/5f5c4b37-160e-520b-abcf-f1a805edb1fa.yaml
+++ b/geolexica-v2/5f5c4b37-160e-520b-abcf-f1a805edb1fa.yaml
@@ -7,7 +7,6 @@ id: 5f5c4b37-160e-520b-abcf-f1a805edb1fa
 
 ---
 data:
-  definition: []
   examples: []
   id: '114'
   notes: []

--- a/geolexica-v2/62616b84-12aa-558d-97b0-b5b29618b2b1.yaml
+++ b/geolexica-v2/62616b84-12aa-558d-97b0-b5b29618b2b1.yaml
@@ -7,7 +7,6 @@ id: 62616b84-12aa-558d-97b0-b5b29618b2b1
 
 ---
 data:
-  definition: []
   examples: []
   id: '250'
   notes: []

--- a/geolexica-v2/634e8859-fa55-5b73-9ab8-937e445ef1a6.yaml
+++ b/geolexica-v2/634e8859-fa55-5b73-9ab8-937e445ef1a6.yaml
@@ -7,7 +7,6 @@ id: 634e8859-fa55-5b73-9ab8-937e445ef1a6
 
 ---
 data:
-  definition: []
   examples: []
   id: '119'
   notes: []

--- a/geolexica-v2/64299c87-b4de-56cd-9f49-78bd01dc74ca.yaml
+++ b/geolexica-v2/64299c87-b4de-56cd-9f49-78bd01dc74ca.yaml
@@ -7,7 +7,6 @@ id: 64299c87-b4de-56cd-9f49-78bd01dc74ca
 
 ---
 data:
-  definition: []
   examples: []
   id: '108'
   notes: []

--- a/geolexica-v2/65145bf2-ba4d-580b-81fa-bbeccf7d5bc5.yaml
+++ b/geolexica-v2/65145bf2-ba4d-580b-81fa-bbeccf7d5bc5.yaml
@@ -7,7 +7,6 @@ id: 65145bf2-ba4d-580b-81fa-bbeccf7d5bc5
 
 ---
 data:
-  definition: []
   examples: []
   id: '297'
   notes: []

--- a/geolexica-v2/6591ab5a-2c78-5404-a59f-6d40e78e4948.yaml
+++ b/geolexica-v2/6591ab5a-2c78-5404-a59f-6d40e78e4948.yaml
@@ -7,7 +7,6 @@ id: 6591ab5a-2c78-5404-a59f-6d40e78e4948
 
 ---
 data:
-  definition: []
   examples: []
   id: '95'
   notes: []

--- a/geolexica-v2/672713a5-7f7a-5fe7-98e1-676b3376fac0.yaml
+++ b/geolexica-v2/672713a5-7f7a-5fe7-98e1-676b3376fac0.yaml
@@ -7,7 +7,6 @@ id: 672713a5-7f7a-5fe7-98e1-676b3376fac0
 
 ---
 data:
-  definition: []
   examples: []
   id: '312'
   notes: []

--- a/geolexica-v2/67af511b-d8f5-5678-9573-5f9ed23f0672.yaml
+++ b/geolexica-v2/67af511b-d8f5-5678-9573-5f9ed23f0672.yaml
@@ -7,7 +7,6 @@ id: 67af511b-d8f5-5678-9573-5f9ed23f0672
 
 ---
 data:
-  definition: []
   examples: []
   id: '424'
   notes: []

--- a/geolexica-v2/68a0790e-7e0e-5e90-b972-a78a14bb5e81.yaml
+++ b/geolexica-v2/68a0790e-7e0e-5e90-b972-a78a14bb5e81.yaml
@@ -7,7 +7,6 @@ id: 68a0790e-7e0e-5e90-b972-a78a14bb5e81
 
 ---
 data:
-  definition: []
   examples: []
   id: '53'
   notes: []

--- a/geolexica-v2/6a8648cc-16db-50cd-b0d7-e2365b5dc1f4.yaml
+++ b/geolexica-v2/6a8648cc-16db-50cd-b0d7-e2365b5dc1f4.yaml
@@ -7,7 +7,6 @@ id: 6a8648cc-16db-50cd-b0d7-e2365b5dc1f4
 
 ---
 data:
-  definition: []
   examples: []
   id: '237'
   notes: []

--- a/geolexica-v2/6aa77859-f06d-55a0-8e7a-e21e00c5a47f.yaml
+++ b/geolexica-v2/6aa77859-f06d-55a0-8e7a-e21e00c5a47f.yaml
@@ -7,7 +7,6 @@ id: 6aa77859-f06d-55a0-8e7a-e21e00c5a47f
 
 ---
 data:
-  definition: []
   examples: []
   id: '177'
   notes: []

--- a/geolexica-v2/6af492be-9674-5d41-ba10-dd0533e90709.yaml
+++ b/geolexica-v2/6af492be-9674-5d41-ba10-dd0533e90709.yaml
@@ -7,7 +7,6 @@ id: 6af492be-9674-5d41-ba10-dd0533e90709
 
 ---
 data:
-  definition: []
   examples: []
   id: '331'
   notes: []

--- a/geolexica-v2/6b4c85b4-4644-58d7-84d3-ce086c6a59de.yaml
+++ b/geolexica-v2/6b4c85b4-4644-58d7-84d3-ce086c6a59de.yaml
@@ -7,7 +7,6 @@ id: 6b4c85b4-4644-58d7-84d3-ce086c6a59de
 
 ---
 data:
-  definition: []
   examples: []
   id: '335'
   notes: []

--- a/geolexica-v2/6baf2db8-ba07-547b-99b8-dd22fdf9f78e.yaml
+++ b/geolexica-v2/6baf2db8-ba07-547b-99b8-dd22fdf9f78e.yaml
@@ -7,7 +7,6 @@ id: 6baf2db8-ba07-547b-99b8-dd22fdf9f78e
 
 ---
 data:
-  definition: []
   examples: []
   id: '110'
   notes: []

--- a/geolexica-v2/6d2ac0a8-2d0c-5986-9d96-26f2f83576ab.yaml
+++ b/geolexica-v2/6d2ac0a8-2d0c-5986-9d96-26f2f83576ab.yaml
@@ -7,7 +7,6 @@ id: 6d2ac0a8-2d0c-5986-9d96-26f2f83576ab
 
 ---
 data:
-  definition: []
   examples: []
   id: '100'
   notes: []

--- a/geolexica-v2/6ee83b3c-d8c6-5b53-9945-0c108583b1a4.yaml
+++ b/geolexica-v2/6ee83b3c-d8c6-5b53-9945-0c108583b1a4.yaml
@@ -7,7 +7,6 @@ id: 6ee83b3c-d8c6-5b53-9945-0c108583b1a4
 
 ---
 data:
-  definition: []
   examples: []
   id: '400'
   notes: []

--- a/geolexica-v2/700cb5c3-4761-51c7-b9f8-4e292d201bfe.yaml
+++ b/geolexica-v2/700cb5c3-4761-51c7-b9f8-4e292d201bfe.yaml
@@ -7,7 +7,6 @@ id: 700cb5c3-4761-51c7-b9f8-4e292d201bfe
 
 ---
 data:
-  definition: []
   examples: []
   id: '441'
   notes: []

--- a/geolexica-v2/70962778-8528-57ab-8a42-3134cf646cd4.yaml
+++ b/geolexica-v2/70962778-8528-57ab-8a42-3134cf646cd4.yaml
@@ -7,7 +7,6 @@ id: 70962778-8528-57ab-8a42-3134cf646cd4
 
 ---
 data:
-  definition: []
   examples: []
   id: '367'
   notes: []

--- a/geolexica-v2/7229c50e-1572-537e-88c3-2f64f3444a75.yaml
+++ b/geolexica-v2/7229c50e-1572-537e-88c3-2f64f3444a75.yaml
@@ -7,7 +7,6 @@ id: 7229c50e-1572-537e-88c3-2f64f3444a75
 
 ---
 data:
-  definition: []
   examples: []
   id: '3'
   notes: []

--- a/geolexica-v2/72539202-5605-5842-a86f-a5a1f9aeb536.yaml
+++ b/geolexica-v2/72539202-5605-5842-a86f-a5a1f9aeb536.yaml
@@ -7,7 +7,6 @@ id: 72539202-5605-5842-a86f-a5a1f9aeb536
 
 ---
 data:
-  definition: []
   examples: []
   id: '65'
   notes: []

--- a/geolexica-v2/73a49a21-7d3e-55fb-8340-dbf5f1c4a2bc.yaml
+++ b/geolexica-v2/73a49a21-7d3e-55fb-8340-dbf5f1c4a2bc.yaml
@@ -7,7 +7,6 @@ id: 73a49a21-7d3e-55fb-8340-dbf5f1c4a2bc
 
 ---
 data:
-  definition: []
   examples: []
   id: '416'
   notes: []

--- a/geolexica-v2/747681f1-9763-5892-b1e5-78259c7337a8.yaml
+++ b/geolexica-v2/747681f1-9763-5892-b1e5-78259c7337a8.yaml
@@ -7,7 +7,6 @@ id: 747681f1-9763-5892-b1e5-78259c7337a8
 
 ---
 data:
-  definition: []
   examples: []
   id: '190'
   notes: []

--- a/geolexica-v2/74ee5f5b-61c9-560c-a640-2f98390d0149.yaml
+++ b/geolexica-v2/74ee5f5b-61c9-560c-a640-2f98390d0149.yaml
@@ -7,7 +7,6 @@ id: 74ee5f5b-61c9-560c-a640-2f98390d0149
 
 ---
 data:
-  definition: []
   examples: []
   id: '217'
   notes: []

--- a/geolexica-v2/75699c1c-6056-51e1-b55f-1f76ca567546.yaml
+++ b/geolexica-v2/75699c1c-6056-51e1-b55f-1f76ca567546.yaml
@@ -7,7 +7,6 @@ id: 75699c1c-6056-51e1-b55f-1f76ca567546
 
 ---
 data:
-  definition: []
   examples: []
   id: '318'
   notes: []

--- a/geolexica-v2/763d3e86-da69-50e8-80b4-cb92d58fadcb.yaml
+++ b/geolexica-v2/763d3e86-da69-50e8-80b4-cb92d58fadcb.yaml
@@ -7,7 +7,6 @@ id: 763d3e86-da69-50e8-80b4-cb92d58fadcb
 
 ---
 data:
-  definition: []
   examples: []
   id: '355'
   notes: []

--- a/geolexica-v2/76cc2b9e-fd97-57a0-9140-b73a2b350a6f.yaml
+++ b/geolexica-v2/76cc2b9e-fd97-57a0-9140-b73a2b350a6f.yaml
@@ -7,7 +7,6 @@ id: 76cc2b9e-fd97-57a0-9140-b73a2b350a6f
 
 ---
 data:
-  definition: []
   examples: []
   id: '73'
   notes: []

--- a/geolexica-v2/78d93ce9-c7b6-52d5-9cf3-1068c258a21d.yaml
+++ b/geolexica-v2/78d93ce9-c7b6-52d5-9cf3-1068c258a21d.yaml
@@ -7,7 +7,6 @@ id: 78d93ce9-c7b6-52d5-9cf3-1068c258a21d
 
 ---
 data:
-  definition: []
   examples: []
   id: '422'
   notes: []

--- a/geolexica-v2/78ef8db2-ec9a-52f3-8c27-dcc3cef1f9f6.yaml
+++ b/geolexica-v2/78ef8db2-ec9a-52f3-8c27-dcc3cef1f9f6.yaml
@@ -7,7 +7,6 @@ id: 78ef8db2-ec9a-52f3-8c27-dcc3cef1f9f6
 
 ---
 data:
-  definition: []
   examples: []
   id: '295'
   notes: []

--- a/geolexica-v2/7af5992a-a813-5377-8df2-df2af552bbef.yaml
+++ b/geolexica-v2/7af5992a-a813-5377-8df2-df2af552bbef.yaml
@@ -7,7 +7,6 @@ id: 7af5992a-a813-5377-8df2-df2af552bbef
 
 ---
 data:
-  definition: []
   examples: []
   id: '18'
   notes: []

--- a/geolexica-v2/7f0467af-34d5-5e28-a7ff-7f0bccd7f12d.yaml
+++ b/geolexica-v2/7f0467af-34d5-5e28-a7ff-7f0bccd7f12d.yaml
@@ -7,7 +7,6 @@ id: 7f0467af-34d5-5e28-a7ff-7f0bccd7f12d
 
 ---
 data:
-  definition: []
   examples: []
   id: '369'
   notes: []

--- a/geolexica-v2/8067a3d1-648a-58a6-bac6-7ed8f33709ac.yaml
+++ b/geolexica-v2/8067a3d1-648a-58a6-bac6-7ed8f33709ac.yaml
@@ -7,7 +7,6 @@ id: 8067a3d1-648a-58a6-bac6-7ed8f33709ac
 
 ---
 data:
-  definition: []
   examples: []
   id: '40'
   notes: []

--- a/geolexica-v2/807a7b2a-673e-5d72-b638-86f5bb1a8465.yaml
+++ b/geolexica-v2/807a7b2a-673e-5d72-b638-86f5bb1a8465.yaml
@@ -7,7 +7,6 @@ id: 807a7b2a-673e-5d72-b638-86f5bb1a8465
 
 ---
 data:
-  definition: []
   examples: []
   id: '365'
   notes: []

--- a/geolexica-v2/818656d7-f839-5503-88cd-6b6b4cc97770.yaml
+++ b/geolexica-v2/818656d7-f839-5503-88cd-6b6b4cc97770.yaml
@@ -7,7 +7,6 @@ id: 818656d7-f839-5503-88cd-6b6b4cc97770
 
 ---
 data:
-  definition: []
   examples: []
   id: '351'
   notes: []

--- a/geolexica-v2/83a8491d-a4a7-5d2e-805f-f50f825b2c62.yaml
+++ b/geolexica-v2/83a8491d-a4a7-5d2e-805f-f50f825b2c62.yaml
@@ -7,7 +7,6 @@ id: 83a8491d-a4a7-5d2e-805f-f50f825b2c62
 
 ---
 data:
-  definition: []
   examples: []
   id: '428'
   notes: []

--- a/geolexica-v2/895790c3-07c3-5e2d-b3ab-0e08795468a3.yaml
+++ b/geolexica-v2/895790c3-07c3-5e2d-b3ab-0e08795468a3.yaml
@@ -7,7 +7,6 @@ id: 895790c3-07c3-5e2d-b3ab-0e08795468a3
 
 ---
 data:
-  definition: []
   examples: []
   id: '219'
   notes: []

--- a/geolexica-v2/8b2eec37-901f-5ebb-a213-501ff4b24f8f.yaml
+++ b/geolexica-v2/8b2eec37-901f-5ebb-a213-501ff4b24f8f.yaml
@@ -7,7 +7,6 @@ id: 8b2eec37-901f-5ebb-a213-501ff4b24f8f
 
 ---
 data:
-  definition: []
   examples: []
   id: '241'
   notes: []

--- a/geolexica-v2/8c459e07-a03a-58e8-89d3-21e49e8246ff.yaml
+++ b/geolexica-v2/8c459e07-a03a-58e8-89d3-21e49e8246ff.yaml
@@ -7,7 +7,6 @@ id: 8c459e07-a03a-58e8-89d3-21e49e8246ff
 
 ---
 data:
-  definition: []
   examples: []
   id: '152'
   notes: []

--- a/geolexica-v2/8d21b939-7766-5795-b67c-02f5bdf68eaf.yaml
+++ b/geolexica-v2/8d21b939-7766-5795-b67c-02f5bdf68eaf.yaml
@@ -7,7 +7,6 @@ id: 8d21b939-7766-5795-b67c-02f5bdf68eaf
 
 ---
 data:
-  definition: []
   examples: []
   id: '172'
   notes: []

--- a/geolexica-v2/8f24f2a0-bcb2-58af-9b13-fd8ebce021f6.yaml
+++ b/geolexica-v2/8f24f2a0-bcb2-58af-9b13-fd8ebce021f6.yaml
@@ -7,7 +7,6 @@ id: 8f24f2a0-bcb2-58af-9b13-fd8ebce021f6
 
 ---
 data:
-  definition: []
   examples: []
   id: '360'
   notes: []

--- a/geolexica-v2/8f8d2d21-c2dc-583b-8532-5df3debf78c0.yaml
+++ b/geolexica-v2/8f8d2d21-c2dc-583b-8532-5df3debf78c0.yaml
@@ -7,7 +7,6 @@ id: 8f8d2d21-c2dc-583b-8532-5df3debf78c0
 
 ---
 data:
-  definition: []
   examples: []
   id: '352'
   notes: []

--- a/geolexica-v2/8fdfb550-8ee6-52e2-b7ee-2e485c999a8f.yaml
+++ b/geolexica-v2/8fdfb550-8ee6-52e2-b7ee-2e485c999a8f.yaml
@@ -7,7 +7,6 @@ id: 8fdfb550-8ee6-52e2-b7ee-2e485c999a8f
 
 ---
 data:
-  definition: []
   examples: []
   id: '248'
   notes: []

--- a/geolexica-v2/910adf62-584c-5764-949b-e3249d343b2d.yaml
+++ b/geolexica-v2/910adf62-584c-5764-949b-e3249d343b2d.yaml
@@ -7,7 +7,6 @@ id: 910adf62-584c-5764-949b-e3249d343b2d
 
 ---
 data:
-  definition: []
   examples: []
   id: '421'
   notes: []

--- a/geolexica-v2/913a1b53-eb4b-549b-84a5-8812dace62e5.yaml
+++ b/geolexica-v2/913a1b53-eb4b-549b-84a5-8812dace62e5.yaml
@@ -7,7 +7,6 @@ id: 913a1b53-eb4b-549b-84a5-8812dace62e5
 
 ---
 data:
-  definition: []
   examples: []
   id: '38'
   notes: []

--- a/geolexica-v2/9483d397-c2f4-565b-ae64-7ae1062424ef.yaml
+++ b/geolexica-v2/9483d397-c2f4-565b-ae64-7ae1062424ef.yaml
@@ -7,7 +7,6 @@ id: 9483d397-c2f4-565b-ae64-7ae1062424ef
 
 ---
 data:
-  definition: []
   examples: []
   id: '39'
   notes: []

--- a/geolexica-v2/948c8dc7-72db-5972-a585-70f46e481f93.yaml
+++ b/geolexica-v2/948c8dc7-72db-5972-a585-70f46e481f93.yaml
@@ -7,7 +7,6 @@ id: 948c8dc7-72db-5972-a585-70f46e481f93
 
 ---
 data:
-  definition: []
   examples: []
   id: '146'
   notes: []

--- a/geolexica-v2/95401d31-95f6-57ef-a9a6-695d5df783f2.yaml
+++ b/geolexica-v2/95401d31-95f6-57ef-a9a6-695d5df783f2.yaml
@@ -7,7 +7,6 @@ id: 95401d31-95f6-57ef-a9a6-695d5df783f2
 
 ---
 data:
-  definition: []
   examples: []
   id: '21'
   notes: []

--- a/geolexica-v2/955c3dff-dd04-5b8e-b3d2-c4d1721ff3d9.yaml
+++ b/geolexica-v2/955c3dff-dd04-5b8e-b3d2-c4d1721ff3d9.yaml
@@ -7,7 +7,6 @@ id: 955c3dff-dd04-5b8e-b3d2-c4d1721ff3d9
 
 ---
 data:
-  definition: []
   examples: []
   id: '7'
   notes: []

--- a/geolexica-v2/956fee58-e13d-5401-8432-cd44e00cd450.yaml
+++ b/geolexica-v2/956fee58-e13d-5401-8432-cd44e00cd450.yaml
@@ -7,7 +7,6 @@ id: 956fee58-e13d-5401-8432-cd44e00cd450
 
 ---
 data:
-  definition: []
   examples: []
   id: '267'
   notes: []

--- a/geolexica-v2/9792a6e3-7aee-5f64-80d4-bd53452f6b95.yaml
+++ b/geolexica-v2/9792a6e3-7aee-5f64-80d4-bd53452f6b95.yaml
@@ -7,7 +7,6 @@ id: 9792a6e3-7aee-5f64-80d4-bd53452f6b95
 
 ---
 data:
-  definition: []
   examples: []
   id: '107'
   notes: []

--- a/geolexica-v2/9815a5dc-b7fe-54fc-9c85-2e79ad80d93e.yaml
+++ b/geolexica-v2/9815a5dc-b7fe-54fc-9c85-2e79ad80d93e.yaml
@@ -7,7 +7,6 @@ id: 9815a5dc-b7fe-54fc-9c85-2e79ad80d93e
 
 ---
 data:
-  definition: []
   examples: []
   id: '311'
   notes: []

--- a/geolexica-v2/984931f8-73ee-5a36-9e81-dcc1307e780c.yaml
+++ b/geolexica-v2/984931f8-73ee-5a36-9e81-dcc1307e780c.yaml
@@ -7,7 +7,6 @@ id: 984931f8-73ee-5a36-9e81-dcc1307e780c
 
 ---
 data:
-  definition: []
   examples: []
   id: '207'
   notes: []

--- a/geolexica-v2/98a61d37-d66f-57a0-8c28-2075bc52b2b7.yaml
+++ b/geolexica-v2/98a61d37-d66f-57a0-8c28-2075bc52b2b7.yaml
@@ -7,7 +7,6 @@ id: 98a61d37-d66f-57a0-8c28-2075bc52b2b7
 
 ---
 data:
-  definition: []
   examples: []
   id: '343'
   notes: []

--- a/geolexica-v2/98b4f1ce-2cb3-5703-ab10-8b558791729a.yaml
+++ b/geolexica-v2/98b4f1ce-2cb3-5703-ab10-8b558791729a.yaml
@@ -7,7 +7,6 @@ id: 98b4f1ce-2cb3-5703-ab10-8b558791729a
 
 ---
 data:
-  definition: []
   examples: []
   id: '334'
   notes: []

--- a/geolexica-v2/99f76230-38bf-50cd-8ab5-8432da6f1e83.yaml
+++ b/geolexica-v2/99f76230-38bf-50cd-8ab5-8432da6f1e83.yaml
@@ -7,7 +7,6 @@ id: 99f76230-38bf-50cd-8ab5-8432da6f1e83
 
 ---
 data:
-  definition: []
   examples: []
   id: '242'
   notes: []

--- a/geolexica-v2/9e456f14-e82c-5d50-9ed1-a66fe263d1e3.yaml
+++ b/geolexica-v2/9e456f14-e82c-5d50-9ed1-a66fe263d1e3.yaml
@@ -7,7 +7,6 @@ id: 9e456f14-e82c-5d50-9ed1-a66fe263d1e3
 
 ---
 data:
-  definition: []
   examples: []
   id: '156'
   notes: []

--- a/geolexica-v2/9f700c1b-fe0e-583e-9adb-4747a7bf9625.yaml
+++ b/geolexica-v2/9f700c1b-fe0e-583e-9adb-4747a7bf9625.yaml
@@ -7,7 +7,6 @@ id: 9f700c1b-fe0e-583e-9adb-4747a7bf9625
 
 ---
 data:
-  definition: []
   examples: []
   id: '358'
   notes: []

--- a/geolexica-v2/9f92983a-3bc7-5b89-bb0e-e5d49b6ce496.yaml
+++ b/geolexica-v2/9f92983a-3bc7-5b89-bb0e-e5d49b6ce496.yaml
@@ -7,7 +7,6 @@ id: 9f92983a-3bc7-5b89-bb0e-e5d49b6ce496
 
 ---
 data:
-  definition: []
   examples: []
   id: '8'
   notes: []

--- a/geolexica-v2/a1641276-c39d-5179-994e-0d04e21d50b9.yaml
+++ b/geolexica-v2/a1641276-c39d-5179-994e-0d04e21d50b9.yaml
@@ -7,7 +7,6 @@ id: a1641276-c39d-5179-994e-0d04e21d50b9
 
 ---
 data:
-  definition: []
   examples: []
   id: '323'
   notes: []

--- a/geolexica-v2/a3acb0d1-073d-5a4c-afa6-3204789511f2.yaml
+++ b/geolexica-v2/a3acb0d1-073d-5a4c-afa6-3204789511f2.yaml
@@ -7,7 +7,6 @@ id: a3acb0d1-073d-5a4c-afa6-3204789511f2
 
 ---
 data:
-  definition: []
   examples: []
   id: '58'
   notes: []

--- a/geolexica-v2/a4e01431-5613-5c6a-b7e9-8549e3e5091e.yaml
+++ b/geolexica-v2/a4e01431-5613-5c6a-b7e9-8549e3e5091e.yaml
@@ -7,7 +7,6 @@ id: a4e01431-5613-5c6a-b7e9-8549e3e5091e
 
 ---
 data:
-  definition: []
   examples: []
   id: '245'
   notes: []

--- a/geolexica-v2/a5486e0e-eede-5744-8ce4-1d3f3b19c4ed.yaml
+++ b/geolexica-v2/a5486e0e-eede-5744-8ce4-1d3f3b19c4ed.yaml
@@ -7,7 +7,6 @@ id: a5486e0e-eede-5744-8ce4-1d3f3b19c4ed
 
 ---
 data:
-  definition: []
   examples: []
   id: '62'
   notes: []

--- a/geolexica-v2/a7770644-8855-5915-8e84-0f570f41266c.yaml
+++ b/geolexica-v2/a7770644-8855-5915-8e84-0f570f41266c.yaml
@@ -7,7 +7,6 @@ id: a7770644-8855-5915-8e84-0f570f41266c
 
 ---
 data:
-  definition: []
   examples: []
   id: '101'
   notes: []

--- a/geolexica-v2/a97a5b0a-f41b-5d7b-81fb-d10747a8efdd.yaml
+++ b/geolexica-v2/a97a5b0a-f41b-5d7b-81fb-d10747a8efdd.yaml
@@ -7,7 +7,6 @@ id: a97a5b0a-f41b-5d7b-81fb-d10747a8efdd
 
 ---
 data:
-  definition: []
   examples: []
   id: '436'
   notes: []

--- a/geolexica-v2/aae34059-11e2-581c-8a1a-d9fac51f09de.yaml
+++ b/geolexica-v2/aae34059-11e2-581c-8a1a-d9fac51f09de.yaml
@@ -7,7 +7,6 @@ id: aae34059-11e2-581c-8a1a-d9fac51f09de
 
 ---
 data:
-  definition: []
   examples: []
   id: '310'
   notes: []

--- a/geolexica-v2/ac3cc81b-1eac-5111-bb28-37ec98506b4f.yaml
+++ b/geolexica-v2/ac3cc81b-1eac-5111-bb28-37ec98506b4f.yaml
@@ -7,7 +7,6 @@ id: ac3cc81b-1eac-5111-bb28-37ec98506b4f
 
 ---
 data:
-  definition: []
   examples: []
   id: '265'
   notes: []

--- a/geolexica-v2/accc1065-80ce-51af-95a5-663dbdbc295e.yaml
+++ b/geolexica-v2/accc1065-80ce-51af-95a5-663dbdbc295e.yaml
@@ -7,7 +7,6 @@ id: accc1065-80ce-51af-95a5-663dbdbc295e
 
 ---
 data:
-  definition: []
   examples: []
   id: '397'
   notes: []

--- a/geolexica-v2/adca716b-b84f-514b-8bc3-720a8c1a9500.yaml
+++ b/geolexica-v2/adca716b-b84f-514b-8bc3-720a8c1a9500.yaml
@@ -7,7 +7,6 @@ id: adca716b-b84f-514b-8bc3-720a8c1a9500
 
 ---
 data:
-  definition: []
   examples: []
   id: '151'
   notes: []

--- a/geolexica-v2/ae5b6f44-f4e8-57c4-ba8f-624d61c21d46.yaml
+++ b/geolexica-v2/ae5b6f44-f4e8-57c4-ba8f-624d61c21d46.yaml
@@ -7,7 +7,6 @@ id: ae5b6f44-f4e8-57c4-ba8f-624d61c21d46
 
 ---
 data:
-  definition: []
   examples: []
   id: '79'
   notes: []

--- a/geolexica-v2/aee1f1c2-810f-58f7-bfca-596a53304ec8.yaml
+++ b/geolexica-v2/aee1f1c2-810f-58f7-bfca-596a53304ec8.yaml
@@ -7,7 +7,6 @@ id: aee1f1c2-810f-58f7-bfca-596a53304ec8
 
 ---
 data:
-  definition: []
   examples: []
   id: '200'
   notes: []

--- a/geolexica-v2/af1b7719-879e-5a3e-bc9d-e3021217512a.yaml
+++ b/geolexica-v2/af1b7719-879e-5a3e-bc9d-e3021217512a.yaml
@@ -7,7 +7,6 @@ id: af1b7719-879e-5a3e-bc9d-e3021217512a
 
 ---
 data:
-  definition: []
   examples: []
   id: '384'
   notes: []

--- a/geolexica-v2/b191263c-b420-5073-b70a-18d0bbd602db.yaml
+++ b/geolexica-v2/b191263c-b420-5073-b70a-18d0bbd602db.yaml
@@ -7,7 +7,6 @@ id: b191263c-b420-5073-b70a-18d0bbd602db
 
 ---
 data:
-  definition: []
   examples: []
   id: '85'
   notes: []

--- a/geolexica-v2/b1aaf6f4-6fff-584d-b076-df44d2da66da.yaml
+++ b/geolexica-v2/b1aaf6f4-6fff-584d-b076-df44d2da66da.yaml
@@ -7,7 +7,6 @@ id: b1aaf6f4-6fff-584d-b076-df44d2da66da
 
 ---
 data:
-  definition: []
   examples: []
   id: '345'
   notes: []

--- a/geolexica-v2/b239b04c-228d-5338-8bcf-45315c7c3991.yaml
+++ b/geolexica-v2/b239b04c-228d-5338-8bcf-45315c7c3991.yaml
@@ -7,7 +7,6 @@ id: b239b04c-228d-5338-8bcf-45315c7c3991
 
 ---
 data:
-  definition: []
   examples: []
   id: '178'
   notes: []

--- a/geolexica-v2/b44ed4fe-ee10-533e-96f2-79a0fb91b633.yaml
+++ b/geolexica-v2/b44ed4fe-ee10-533e-96f2-79a0fb91b633.yaml
@@ -7,7 +7,6 @@ id: b44ed4fe-ee10-533e-96f2-79a0fb91b633
 
 ---
 data:
-  definition: []
   examples: []
   id: '81'
   notes: []

--- a/geolexica-v2/b46fa9af-c173-5907-919b-2ead3edae61c.yaml
+++ b/geolexica-v2/b46fa9af-c173-5907-919b-2ead3edae61c.yaml
@@ -7,7 +7,6 @@ id: b46fa9af-c173-5907-919b-2ead3edae61c
 
 ---
 data:
-  definition: []
   examples: []
   id: '354'
   notes: []

--- a/geolexica-v2/b5de3187-d760-5429-841c-b9a761373e2f.yaml
+++ b/geolexica-v2/b5de3187-d760-5429-841c-b9a761373e2f.yaml
@@ -7,7 +7,6 @@ id: b5de3187-d760-5429-841c-b9a761373e2f
 
 ---
 data:
-  definition: []
   examples: []
   id: '116'
   notes: []

--- a/geolexica-v2/b64acff0-488c-57ba-b0ef-c3d3eb4d99bd.yaml
+++ b/geolexica-v2/b64acff0-488c-57ba-b0ef-c3d3eb4d99bd.yaml
@@ -7,7 +7,6 @@ id: b64acff0-488c-57ba-b0ef-c3d3eb4d99bd
 
 ---
 data:
-  definition: []
   examples: []
   id: '283'
   notes: []

--- a/geolexica-v2/b67617e9-9d90-5fdf-bd4b-457cc105b49b.yaml
+++ b/geolexica-v2/b67617e9-9d90-5fdf-bd4b-457cc105b49b.yaml
@@ -7,7 +7,6 @@ id: b67617e9-9d90-5fdf-bd4b-457cc105b49b
 
 ---
 data:
-  definition: []
   examples: []
   id: '330'
   notes: []

--- a/geolexica-v2/b7407784-062e-5616-8bc1-7adaabf91a0b.yaml
+++ b/geolexica-v2/b7407784-062e-5616-8bc1-7adaabf91a0b.yaml
@@ -7,7 +7,6 @@ id: b7407784-062e-5616-8bc1-7adaabf91a0b
 
 ---
 data:
-  definition: []
   examples: []
   id: '314'
   notes: []

--- a/geolexica-v2/b753770a-06e7-5cde-a701-1c2bb64529a5.yaml
+++ b/geolexica-v2/b753770a-06e7-5cde-a701-1c2bb64529a5.yaml
@@ -7,7 +7,6 @@ id: b753770a-06e7-5cde-a701-1c2bb64529a5
 
 ---
 data:
-  definition: []
   examples: []
   id: '429'
   notes: []

--- a/geolexica-v2/ba8e71da-a8fc-58c1-9926-328cffc06c12.yaml
+++ b/geolexica-v2/ba8e71da-a8fc-58c1-9926-328cffc06c12.yaml
@@ -7,7 +7,6 @@ id: ba8e71da-a8fc-58c1-9926-328cffc06c12
 
 ---
 data:
-  definition: []
   examples: []
   id: '346'
   notes: []

--- a/geolexica-v2/bb767405-4fd9-5618-974e-463459688cd4.yaml
+++ b/geolexica-v2/bb767405-4fd9-5618-974e-463459688cd4.yaml
@@ -7,7 +7,6 @@ id: bb767405-4fd9-5618-974e-463459688cd4
 
 ---
 data:
-  definition: []
   examples: []
   id: '175'
   notes: []

--- a/geolexica-v2/bc0dfb7e-ec09-531b-b0c0-e43f928aadb5.yaml
+++ b/geolexica-v2/bc0dfb7e-ec09-531b-b0c0-e43f928aadb5.yaml
@@ -7,7 +7,6 @@ id: bc0dfb7e-ec09-531b-b0c0-e43f928aadb5
 
 ---
 data:
-  definition: []
   examples: []
   id: '253'
   notes: []

--- a/geolexica-v2/bd412a4e-e6fc-5551-b516-29007f4c4c34.yaml
+++ b/geolexica-v2/bd412a4e-e6fc-5551-b516-29007f4c4c34.yaml
@@ -7,7 +7,6 @@ id: bd412a4e-e6fc-5551-b516-29007f4c4c34
 
 ---
 data:
-  definition: []
   examples: []
   id: '2'
   notes: []

--- a/geolexica-v2/be83c3bf-6133-5a48-9afe-1733afd2cb06.yaml
+++ b/geolexica-v2/be83c3bf-6133-5a48-9afe-1733afd2cb06.yaml
@@ -7,7 +7,6 @@ id: be83c3bf-6133-5a48-9afe-1733afd2cb06
 
 ---
 data:
-  definition: []
   examples: []
   id: '290'
   notes: []

--- a/geolexica-v2/bebfe3d0-1d7e-5c24-be44-1250e4aa95a6.yaml
+++ b/geolexica-v2/bebfe3d0-1d7e-5c24-be44-1250e4aa95a6.yaml
@@ -7,7 +7,6 @@ id: bebfe3d0-1d7e-5c24-be44-1250e4aa95a6
 
 ---
 data:
-  definition: []
   examples: []
   id: '272'
   notes: []

--- a/geolexica-v2/c045c77c-d40d-59d6-b0d6-b574a4393201.yaml
+++ b/geolexica-v2/c045c77c-d40d-59d6-b0d6-b574a4393201.yaml
@@ -7,7 +7,6 @@ id: c045c77c-d40d-59d6-b0d6-b574a4393201
 
 ---
 data:
-  definition: []
   examples: []
   id: '196'
   notes: []

--- a/geolexica-v2/c18300d4-442b-585f-94ad-8375288cadec.yaml
+++ b/geolexica-v2/c18300d4-442b-585f-94ad-8375288cadec.yaml
@@ -7,7 +7,6 @@ id: c18300d4-442b-585f-94ad-8375288cadec
 
 ---
 data:
-  definition: []
   examples: []
   id: '27'
   notes: []

--- a/geolexica-v2/c199afdd-7d81-51ad-bfc2-e9871f86cd2e.yaml
+++ b/geolexica-v2/c199afdd-7d81-51ad-bfc2-e9871f86cd2e.yaml
@@ -7,7 +7,6 @@ id: c199afdd-7d81-51ad-bfc2-e9871f86cd2e
 
 ---
 data:
-  definition: []
   examples: []
   id: '238'
   notes: []

--- a/geolexica-v2/c27917de-6fed-5f00-b29c-4ecba96c9d9a.yaml
+++ b/geolexica-v2/c27917de-6fed-5f00-b29c-4ecba96c9d9a.yaml
@@ -7,7 +7,6 @@ id: c27917de-6fed-5f00-b29c-4ecba96c9d9a
 
 ---
 data:
-  definition: []
   examples: []
   id: '269'
   notes: []

--- a/geolexica-v2/c2cf9210-9dd6-5d9e-9eab-2bb4b5b933e0.yaml
+++ b/geolexica-v2/c2cf9210-9dd6-5d9e-9eab-2bb4b5b933e0.yaml
@@ -7,7 +7,6 @@ id: c2cf9210-9dd6-5d9e-9eab-2bb4b5b933e0
 
 ---
 data:
-  definition: []
   examples: []
   id: '261'
   notes: []

--- a/geolexica-v2/c32bc39f-a1bc-5c96-b017-8e5f45a8eb0f.yaml
+++ b/geolexica-v2/c32bc39f-a1bc-5c96-b017-8e5f45a8eb0f.yaml
@@ -7,7 +7,6 @@ id: c32bc39f-a1bc-5c96-b017-8e5f45a8eb0f
 
 ---
 data:
-  definition: []
   examples: []
   id: '389'
   notes: []

--- a/geolexica-v2/c4c06cf7-690a-5274-a4ca-975ceb684601.yaml
+++ b/geolexica-v2/c4c06cf7-690a-5274-a4ca-975ceb684601.yaml
@@ -7,7 +7,6 @@ id: c4c06cf7-690a-5274-a4ca-975ceb684601
 
 ---
 data:
-  definition: []
   examples: []
   id: '322'
   notes: []

--- a/geolexica-v2/c6d635b8-6ee8-5805-8d26-3b9fd1745a10.yaml
+++ b/geolexica-v2/c6d635b8-6ee8-5805-8d26-3b9fd1745a10.yaml
@@ -7,7 +7,6 @@ id: c6d635b8-6ee8-5805-8d26-3b9fd1745a10
 
 ---
 data:
-  definition: []
   examples: []
   id: '435'
   notes: []

--- a/geolexica-v2/c705c360-2eb2-5cff-99f3-d8380eb8f24f.yaml
+++ b/geolexica-v2/c705c360-2eb2-5cff-99f3-d8380eb8f24f.yaml
@@ -7,7 +7,6 @@ id: c705c360-2eb2-5cff-99f3-d8380eb8f24f
 
 ---
 data:
-  definition: []
   examples: []
   id: '277'
   notes: []

--- a/geolexica-v2/c8497a5d-3963-5dd7-b2cd-5af1f0177153.yaml
+++ b/geolexica-v2/c8497a5d-3963-5dd7-b2cd-5af1f0177153.yaml
@@ -7,7 +7,6 @@ id: c8497a5d-3963-5dd7-b2cd-5af1f0177153
 
 ---
 data:
-  definition: []
   examples: []
   id: '341'
   notes: []

--- a/geolexica-v2/c87961bb-7fa1-545a-a5d5-80e25f23a86b.yaml
+++ b/geolexica-v2/c87961bb-7fa1-545a-a5d5-80e25f23a86b.yaml
@@ -7,7 +7,6 @@ id: c87961bb-7fa1-545a-a5d5-80e25f23a86b
 
 ---
 data:
-  definition: []
   examples: []
   id: '299'
   notes: []

--- a/geolexica-v2/c96edf59-7002-54e2-9520-3c1b6f541a8c.yaml
+++ b/geolexica-v2/c96edf59-7002-54e2-9520-3c1b6f541a8c.yaml
@@ -7,7 +7,6 @@ id: c96edf59-7002-54e2-9520-3c1b6f541a8c
 
 ---
 data:
-  definition: []
   examples: []
   id: '197'
   notes: []

--- a/geolexica-v2/ca335be5-7141-55f7-8f56-e1c7f250ebb6.yaml
+++ b/geolexica-v2/ca335be5-7141-55f7-8f56-e1c7f250ebb6.yaml
@@ -7,7 +7,6 @@ id: ca335be5-7141-55f7-8f56-e1c7f250ebb6
 
 ---
 data:
-  definition: []
   examples: []
   id: '176'
   notes: []

--- a/geolexica-v2/cc149d12-14b3-5519-beed-e48b5ec4feef.yaml
+++ b/geolexica-v2/cc149d12-14b3-5519-beed-e48b5ec4feef.yaml
@@ -7,7 +7,6 @@ id: cc149d12-14b3-5519-beed-e48b5ec4feef
 
 ---
 data:
-  definition: []
   examples: []
   id: '161'
   notes: []

--- a/geolexica-v2/cc479d63-70df-55e9-b9ac-fc689b169f8b.yaml
+++ b/geolexica-v2/cc479d63-70df-55e9-b9ac-fc689b169f8b.yaml
@@ -7,7 +7,6 @@ id: cc479d63-70df-55e9-b9ac-fc689b169f8b
 
 ---
 data:
-  definition: []
   examples: []
   id: '162'
   notes: []

--- a/geolexica-v2/cca41e27-7b0f-52cb-8f8c-63de0a0f85da.yaml
+++ b/geolexica-v2/cca41e27-7b0f-52cb-8f8c-63de0a0f85da.yaml
@@ -7,7 +7,6 @@ id: cca41e27-7b0f-52cb-8f8c-63de0a0f85da
 
 ---
 data:
-  definition: []
   examples: []
   id: '306'
   notes: []

--- a/geolexica-v2/ccb30959-4a66-5eed-a9cf-139ae324c269.yaml
+++ b/geolexica-v2/ccb30959-4a66-5eed-a9cf-139ae324c269.yaml
@@ -7,7 +7,6 @@ id: ccb30959-4a66-5eed-a9cf-139ae324c269
 
 ---
 data:
-  definition: []
   examples: []
   id: '327'
   notes: []

--- a/geolexica-v2/cccef4d6-98e6-5931-9a54-a561e749b22c.yaml
+++ b/geolexica-v2/cccef4d6-98e6-5931-9a54-a561e749b22c.yaml
@@ -7,7 +7,6 @@ id: cccef4d6-98e6-5931-9a54-a561e749b22c
 
 ---
 data:
-  definition: []
   examples: []
   id: '186'
   notes: []

--- a/geolexica-v2/cfe30052-721d-5425-8f18-1a48688edcd4.yaml
+++ b/geolexica-v2/cfe30052-721d-5425-8f18-1a48688edcd4.yaml
@@ -7,7 +7,6 @@ id: cfe30052-721d-5425-8f18-1a48688edcd4
 
 ---
 data:
-  definition: []
   examples: []
   id: '92'
   notes: []

--- a/geolexica-v2/d046264f-086a-5daf-85b8-4b1ab322ff90.yaml
+++ b/geolexica-v2/d046264f-086a-5daf-85b8-4b1ab322ff90.yaml
@@ -7,7 +7,6 @@ id: d046264f-086a-5daf-85b8-4b1ab322ff90
 
 ---
 data:
-  definition: []
   examples: []
   id: '247'
   notes: []

--- a/geolexica-v2/d0b78845-bfdb-5d15-ae43-0ba47676037b.yaml
+++ b/geolexica-v2/d0b78845-bfdb-5d15-ae43-0ba47676037b.yaml
@@ -7,7 +7,6 @@ id: d0b78845-bfdb-5d15-ae43-0ba47676037b
 
 ---
 data:
-  definition: []
   examples: []
   id: '308'
   notes: []

--- a/geolexica-v2/d1e888fb-9c91-5ef0-9715-3c3cdd3edf11.yaml
+++ b/geolexica-v2/d1e888fb-9c91-5ef0-9715-3c3cdd3edf11.yaml
@@ -7,7 +7,6 @@ id: d1e888fb-9c91-5ef0-9715-3c3cdd3edf11
 
 ---
 data:
-  definition: []
   examples: []
   id: '12'
   notes: []

--- a/geolexica-v2/d2553eb7-aa46-57a2-9785-c1f2e98af02c.yaml
+++ b/geolexica-v2/d2553eb7-aa46-57a2-9785-c1f2e98af02c.yaml
@@ -7,7 +7,6 @@ id: d2553eb7-aa46-57a2-9785-c1f2e98af02c
 
 ---
 data:
-  definition: []
   examples: []
   id: '9'
   notes: []

--- a/geolexica-v2/d31248d4-da64-5a07-bb0a-2874aebdcd55.yaml
+++ b/geolexica-v2/d31248d4-da64-5a07-bb0a-2874aebdcd55.yaml
@@ -7,7 +7,6 @@ id: d31248d4-da64-5a07-bb0a-2874aebdcd55
 
 ---
 data:
-  definition: []
   examples: []
   id: '19'
   notes: []

--- a/geolexica-v2/d4757a58-4495-5bc4-8e8b-fc535e38ead4.yaml
+++ b/geolexica-v2/d4757a58-4495-5bc4-8e8b-fc535e38ead4.yaml
@@ -7,7 +7,6 @@ id: d4757a58-4495-5bc4-8e8b-fc535e38ead4
 
 ---
 data:
-  definition: []
   examples: []
   id: '410'
   notes: []

--- a/geolexica-v2/d4bdad17-2a78-5ca2-ad07-6611860435db.yaml
+++ b/geolexica-v2/d4bdad17-2a78-5ca2-ad07-6611860435db.yaml
@@ -7,7 +7,6 @@ id: d4bdad17-2a78-5ca2-ad07-6611860435db
 
 ---
 data:
-  definition: []
   examples: []
   id: '344'
   notes: []

--- a/geolexica-v2/d53fc486-f7c3-5499-ab20-65869b11ba9e.yaml
+++ b/geolexica-v2/d53fc486-f7c3-5499-ab20-65869b11ba9e.yaml
@@ -7,7 +7,6 @@ id: d53fc486-f7c3-5499-ab20-65869b11ba9e
 
 ---
 data:
-  definition: []
   examples: []
   id: '23'
   notes: []

--- a/geolexica-v2/d6091aaa-18c4-520c-a6ab-316d766ec899.yaml
+++ b/geolexica-v2/d6091aaa-18c4-520c-a6ab-316d766ec899.yaml
@@ -7,7 +7,6 @@ id: d6091aaa-18c4-520c-a6ab-316d766ec899
 
 ---
 data:
-  definition: []
   examples: []
   id: '25'
   notes: []

--- a/geolexica-v2/d624849f-ef76-52be-b843-e7bb79601d3e.yaml
+++ b/geolexica-v2/d624849f-ef76-52be-b843-e7bb79601d3e.yaml
@@ -7,7 +7,6 @@ id: d624849f-ef76-52be-b843-e7bb79601d3e
 
 ---
 data:
-  definition: []
   examples: []
   id: '171'
   notes: []

--- a/geolexica-v2/d6dcaaed-66ee-5bd7-a528-3e8974c3d145.yaml
+++ b/geolexica-v2/d6dcaaed-66ee-5bd7-a528-3e8974c3d145.yaml
@@ -7,7 +7,6 @@ id: d6dcaaed-66ee-5bd7-a528-3e8974c3d145
 
 ---
 data:
-  definition: []
   examples: []
   id: '15'
   notes: []

--- a/geolexica-v2/d74d5729-f28d-564b-b1d4-4b95b5b379df.yaml
+++ b/geolexica-v2/d74d5729-f28d-564b-b1d4-4b95b5b379df.yaml
@@ -7,7 +7,6 @@ id: d74d5729-f28d-564b-b1d4-4b95b5b379df
 
 ---
 data:
-  definition: []
   examples: []
   id: '157'
   notes:

--- a/geolexica-v2/d8d9fef9-b9fa-5ab0-870b-a74138cf906f.yaml
+++ b/geolexica-v2/d8d9fef9-b9fa-5ab0-870b-a74138cf906f.yaml
@@ -7,7 +7,6 @@ id: d8d9fef9-b9fa-5ab0-870b-a74138cf906f
 
 ---
 data:
-  definition: []
   examples: []
   id: '180'
   notes: []

--- a/geolexica-v2/d9128870-e2df-5cf3-87da-7e1d9cf77747.yaml
+++ b/geolexica-v2/d9128870-e2df-5cf3-87da-7e1d9cf77747.yaml
@@ -7,7 +7,6 @@ id: d9128870-e2df-5cf3-87da-7e1d9cf77747
 
 ---
 data:
-  definition: []
   examples: []
   id: '118'
   notes: []

--- a/geolexica-v2/da196e43-c81b-528d-a21a-9f6195590607.yaml
+++ b/geolexica-v2/da196e43-c81b-528d-a21a-9f6195590607.yaml
@@ -7,7 +7,6 @@ id: da196e43-c81b-528d-a21a-9f6195590607
 
 ---
 data:
-  definition: []
   examples: []
   id: '10'
   notes: []

--- a/geolexica-v2/db36258e-fdc3-5532-847b-2e0ec402dbe3.yaml
+++ b/geolexica-v2/db36258e-fdc3-5532-847b-2e0ec402dbe3.yaml
@@ -7,7 +7,6 @@ id: db36258e-fdc3-5532-847b-2e0ec402dbe3
 
 ---
 data:
-  definition: []
   examples: []
   id: '31'
   notes: []

--- a/geolexica-v2/dba7502a-7c68-5474-9fc0-93fa0ba50795.yaml
+++ b/geolexica-v2/dba7502a-7c68-5474-9fc0-93fa0ba50795.yaml
@@ -7,7 +7,6 @@ id: dba7502a-7c68-5474-9fc0-93fa0ba50795
 
 ---
 data:
-  definition: []
   examples: []
   id: '427'
   notes: []

--- a/geolexica-v2/dcdce4ca-0bf9-5f95-a0e2-de1156a01acc.yaml
+++ b/geolexica-v2/dcdce4ca-0bf9-5f95-a0e2-de1156a01acc.yaml
@@ -7,7 +7,6 @@ id: dcdce4ca-0bf9-5f95-a0e2-de1156a01acc
 
 ---
 data:
-  definition: []
   examples: []
   id: '270'
   notes: []

--- a/geolexica-v2/dd616a8e-c776-5b13-aa09-9bfbd127b29c.yaml
+++ b/geolexica-v2/dd616a8e-c776-5b13-aa09-9bfbd127b29c.yaml
@@ -7,7 +7,6 @@ id: dd616a8e-c776-5b13-aa09-9bfbd127b29c
 
 ---
 data:
-  definition: []
   examples: []
   id: '394'
   notes: []

--- a/geolexica-v2/ddb54b49-e81b-55a9-af7d-235bb806af6b.yaml
+++ b/geolexica-v2/ddb54b49-e81b-55a9-af7d-235bb806af6b.yaml
@@ -7,7 +7,6 @@ id: ddb54b49-e81b-55a9-af7d-235bb806af6b
 
 ---
 data:
-  definition: []
   examples: []
   id: '51'
   notes: []

--- a/geolexica-v2/dde4add8-f011-51ff-87f9-e73871388a1a.yaml
+++ b/geolexica-v2/dde4add8-f011-51ff-87f9-e73871388a1a.yaml
@@ -7,7 +7,6 @@ id: dde4add8-f011-51ff-87f9-e73871388a1a
 
 ---
 data:
-  definition: []
   examples: []
   id: '348'
   notes: []

--- a/geolexica-v2/df49f871-7621-5ed7-9fe3-9f87dd1aedd0.yaml
+++ b/geolexica-v2/df49f871-7621-5ed7-9fe3-9f87dd1aedd0.yaml
@@ -7,7 +7,6 @@ id: df49f871-7621-5ed7-9fe3-9f87dd1aedd0
 
 ---
 data:
-  definition: []
   examples: []
   id: '326'
   notes: []

--- a/geolexica-v2/e0005834-b9ca-512a-a1fa-5c8bd33bfc77.yaml
+++ b/geolexica-v2/e0005834-b9ca-512a-a1fa-5c8bd33bfc77.yaml
@@ -7,7 +7,6 @@ id: e0005834-b9ca-512a-a1fa-5c8bd33bfc77
 
 ---
 data:
-  definition: []
   examples: []
   id: '198'
   notes: []

--- a/geolexica-v2/e11b975b-ad85-5f8b-aea9-840cd0bcc48d.yaml
+++ b/geolexica-v2/e11b975b-ad85-5f8b-aea9-840cd0bcc48d.yaml
@@ -7,7 +7,6 @@ id: e11b975b-ad85-5f8b-aea9-840cd0bcc48d
 
 ---
 data:
-  definition: []
   examples: []
   id: '115'
   notes: []

--- a/geolexica-v2/e227a32e-223c-5e9a-b79c-7c2922162fc0.yaml
+++ b/geolexica-v2/e227a32e-223c-5e9a-b79c-7c2922162fc0.yaml
@@ -7,7 +7,6 @@ id: e227a32e-223c-5e9a-b79c-7c2922162fc0
 
 ---
 data:
-  definition: []
   examples: []
   id: '413'
   notes: []

--- a/geolexica-v2/e2564574-21d3-50e9-bcbe-067a1c7425fd.yaml
+++ b/geolexica-v2/e2564574-21d3-50e9-bcbe-067a1c7425fd.yaml
@@ -7,7 +7,6 @@ id: e2564574-21d3-50e9-bcbe-067a1c7425fd
 
 ---
 data:
-  definition: []
   examples: []
   id: '414'
   notes: []

--- a/geolexica-v2/e3078e87-b0c8-520f-9624-8b2d5dbb327b.yaml
+++ b/geolexica-v2/e3078e87-b0c8-520f-9624-8b2d5dbb327b.yaml
@@ -7,7 +7,6 @@ id: e3078e87-b0c8-520f-9624-8b2d5dbb327b
 
 ---
 data:
-  definition: []
   examples: []
   id: '264'
   notes:

--- a/geolexica-v2/e329a2ab-9be3-54f6-ae03-baf0be3c731a.yaml
+++ b/geolexica-v2/e329a2ab-9be3-54f6-ae03-baf0be3c731a.yaml
@@ -7,7 +7,6 @@ id: e329a2ab-9be3-54f6-ae03-baf0be3c731a
 
 ---
 data:
-  definition: []
   examples: []
   id: '91'
   notes: []

--- a/geolexica-v2/e3986bed-ca67-5c71-ae8c-addc42f2dffd.yaml
+++ b/geolexica-v2/e3986bed-ca67-5c71-ae8c-addc42f2dffd.yaml
@@ -7,7 +7,6 @@ id: e3986bed-ca67-5c71-ae8c-addc42f2dffd
 
 ---
 data:
-  definition: []
   examples: []
   id: '183'
   notes: []

--- a/geolexica-v2/e3e4ff81-ad3d-58a5-90b6-00d2f624d505.yaml
+++ b/geolexica-v2/e3e4ff81-ad3d-58a5-90b6-00d2f624d505.yaml
@@ -7,7 +7,6 @@ id: e3e4ff81-ad3d-58a5-90b6-00d2f624d505
 
 ---
 data:
-  definition: []
   examples: []
   id: '440'
   notes: []

--- a/geolexica-v2/e42d976d-7f9d-5295-b84e-4646833ea36d.yaml
+++ b/geolexica-v2/e42d976d-7f9d-5295-b84e-4646833ea36d.yaml
@@ -7,7 +7,6 @@ id: e42d976d-7f9d-5295-b84e-4646833ea36d
 
 ---
 data:
-  definition: []
   examples: []
   id: '128'
   notes: []

--- a/geolexica-v2/e45839e5-a846-525a-8d2f-0622b02c3cc3.yaml
+++ b/geolexica-v2/e45839e5-a846-525a-8d2f-0622b02c3cc3.yaml
@@ -7,7 +7,6 @@ id: e45839e5-a846-525a-8d2f-0622b02c3cc3
 
 ---
 data:
-  definition: []
   examples: []
   id: '395'
   notes: []

--- a/geolexica-v2/e5e0a29b-6ec4-5583-a336-477f0205915a.yaml
+++ b/geolexica-v2/e5e0a29b-6ec4-5583-a336-477f0205915a.yaml
@@ -7,7 +7,6 @@ id: e5e0a29b-6ec4-5583-a336-477f0205915a
 
 ---
 data:
-  definition: []
   examples: []
   id: '143'
   notes: []

--- a/geolexica-v2/e6401bdf-bf76-5ef8-ba64-df384879ca62.yaml
+++ b/geolexica-v2/e6401bdf-bf76-5ef8-ba64-df384879ca62.yaml
@@ -7,7 +7,6 @@ id: e6401bdf-bf76-5ef8-ba64-df384879ca62
 
 ---
 data:
-  definition: []
   examples: []
   id: '230'
   notes: []

--- a/geolexica-v2/e656e209-1666-5299-b985-04fe52264024.yaml
+++ b/geolexica-v2/e656e209-1666-5299-b985-04fe52264024.yaml
@@ -7,7 +7,6 @@ id: e656e209-1666-5299-b985-04fe52264024
 
 ---
 data:
-  definition: []
   examples: []
   id: '439'
   notes: []

--- a/geolexica-v2/e8e3b7e3-0b8c-5ee3-9565-9fab21af9e63.yaml
+++ b/geolexica-v2/e8e3b7e3-0b8c-5ee3-9565-9fab21af9e63.yaml
@@ -7,7 +7,6 @@ id: e8e3b7e3-0b8c-5ee3-9565-9fab21af9e63
 
 ---
 data:
-  definition: []
   examples: []
   id: '224'
   notes: []

--- a/geolexica-v2/e973e8e6-e04c-5e1a-a24c-77b5e3a0ba26.yaml
+++ b/geolexica-v2/e973e8e6-e04c-5e1a-a24c-77b5e3a0ba26.yaml
@@ -7,7 +7,6 @@ id: e973e8e6-e04c-5e1a-a24c-77b5e3a0ba26
 
 ---
 data:
-  definition: []
   examples: []
   id: '55'
   notes: []

--- a/geolexica-v2/ea33fecd-3f3e-5a8e-aa86-b97d4ee313ef.yaml
+++ b/geolexica-v2/ea33fecd-3f3e-5a8e-aa86-b97d4ee313ef.yaml
@@ -7,7 +7,6 @@ id: ea33fecd-3f3e-5a8e-aa86-b97d4ee313ef
 
 ---
 data:
-  definition: []
   examples: []
   id: '32'
   notes: []

--- a/geolexica-v2/ebcd5820-9f73-5c0d-aeef-7a47d72d4227.yaml
+++ b/geolexica-v2/ebcd5820-9f73-5c0d-aeef-7a47d72d4227.yaml
@@ -7,7 +7,6 @@ id: ebcd5820-9f73-5c0d-aeef-7a47d72d4227
 
 ---
 data:
-  definition: []
   examples: []
   id: '255'
   notes:

--- a/geolexica-v2/ec393b56-9f80-51ef-8276-5a134cf145c0.yaml
+++ b/geolexica-v2/ec393b56-9f80-51ef-8276-5a134cf145c0.yaml
@@ -7,7 +7,6 @@ id: ec393b56-9f80-51ef-8276-5a134cf145c0
 
 ---
 data:
-  definition: []
   examples: []
   id: '282'
   notes: []

--- a/geolexica-v2/ed3dc39e-aeea-541b-ac3d-2099c6f45360.yaml
+++ b/geolexica-v2/ed3dc39e-aeea-541b-ac3d-2099c6f45360.yaml
@@ -7,7 +7,6 @@ id: ed3dc39e-aeea-541b-ac3d-2099c6f45360
 
 ---
 data:
-  definition: []
   examples: []
   id: '188'
   notes: []

--- a/geolexica-v2/edc7b073-ebc3-556d-8226-eff63914e817.yaml
+++ b/geolexica-v2/edc7b073-ebc3-556d-8226-eff63914e817.yaml
@@ -7,7 +7,6 @@ id: edc7b073-ebc3-556d-8226-eff63914e817
 
 ---
 data:
-  definition: []
   examples: []
   id: '286'
   notes: []

--- a/geolexica-v2/edf49324-a2fe-5993-abf9-8018113a6c2c.yaml
+++ b/geolexica-v2/edf49324-a2fe-5993-abf9-8018113a6c2c.yaml
@@ -7,7 +7,6 @@ id: edf49324-a2fe-5993-abf9-8018113a6c2c
 
 ---
 data:
-  definition: []
   examples: []
   id: '99'
   notes: []

--- a/geolexica-v2/ee2c1f19-0b7b-57d2-a846-45f638bc45b6.yaml
+++ b/geolexica-v2/ee2c1f19-0b7b-57d2-a846-45f638bc45b6.yaml
@@ -7,7 +7,6 @@ id: ee2c1f19-0b7b-57d2-a846-45f638bc45b6
 
 ---
 data:
-  definition: []
   examples: []
   id: '392'
   notes: []

--- a/geolexica-v2/ef9192a0-66c2-501c-be70-776807d7142d.yaml
+++ b/geolexica-v2/ef9192a0-66c2-501c-be70-776807d7142d.yaml
@@ -7,7 +7,6 @@ id: ef9192a0-66c2-501c-be70-776807d7142d
 
 ---
 data:
-  definition: []
   examples: []
   id: '142'
   notes: []

--- a/geolexica-v2/f310c49b-c9a1-5f8f-988a-af4ed6df2784.yaml
+++ b/geolexica-v2/f310c49b-c9a1-5f8f-988a-af4ed6df2784.yaml
@@ -7,7 +7,6 @@ id: f310c49b-c9a1-5f8f-988a-af4ed6df2784
 
 ---
 data:
-  definition: []
   examples: []
   id: '342'
   notes: []

--- a/geolexica-v2/f3d46895-45cf-5985-b4e6-ed8012a1c052.yaml
+++ b/geolexica-v2/f3d46895-45cf-5985-b4e6-ed8012a1c052.yaml
@@ -7,7 +7,6 @@ id: f3d46895-45cf-5985-b4e6-ed8012a1c052
 
 ---
 data:
-  definition: []
   examples: []
   id: '225'
   notes: []

--- a/geolexica-v2/f4000bd3-4649-57a3-b09a-84fa0b9318ce.yaml
+++ b/geolexica-v2/f4000bd3-4649-57a3-b09a-84fa0b9318ce.yaml
@@ -7,7 +7,6 @@ id: f4000bd3-4649-57a3-b09a-84fa0b9318ce
 
 ---
 data:
-  definition: []
   examples: []
   id: '64'
   notes: []

--- a/geolexica-v2/f691066d-6154-5354-b42a-48154bcc2b2a.yaml
+++ b/geolexica-v2/f691066d-6154-5354-b42a-48154bcc2b2a.yaml
@@ -7,7 +7,6 @@ id: f691066d-6154-5354-b42a-48154bcc2b2a
 
 ---
 data:
-  definition: []
   examples: []
   id: '174'
   notes: []

--- a/geolexica-v2/f7ebdf03-b260-536d-93cd-277213398bf2.yaml
+++ b/geolexica-v2/f7ebdf03-b260-536d-93cd-277213398bf2.yaml
@@ -7,7 +7,6 @@ id: f7ebdf03-b260-536d-93cd-277213398bf2
 
 ---
 data:
-  definition: []
   examples: []
   id: '199'
   notes: []

--- a/geolexica-v2/fc280ca9-2bc7-56a2-9eed-0a482ae304d5.yaml
+++ b/geolexica-v2/fc280ca9-2bc7-56a2-9eed-0a482ae304d5.yaml
@@ -7,7 +7,6 @@ id: fc280ca9-2bc7-56a2-9eed-0a482ae304d5
 
 ---
 data:
-  definition: []
   examples: []
   id: '86'
   notes: []

--- a/geolexica-v2/fcdeacc8-76fa-5481-9ca5-15f0a466a122.yaml
+++ b/geolexica-v2/fcdeacc8-76fa-5481-9ca5-15f0a466a122.yaml
@@ -7,7 +7,6 @@ id: fcdeacc8-76fa-5481-9ca5-15f0a466a122
 
 ---
 data:
-  definition: []
   examples: []
   id: '350'
   notes: []

--- a/geolexica-v2/fd2b461f-42e6-5ff9-b9f2-6221b45249e4.yaml
+++ b/geolexica-v2/fd2b461f-42e6-5ff9-b9f2-6221b45249e4.yaml
@@ -7,7 +7,6 @@ id: fd2b461f-42e6-5ff9-b9f2-6221b45249e4
 
 ---
 data:
-  definition: []
   examples: []
   id: '173'
   notes: []

--- a/geolexica-v2/fee1aab8-9ed8-5e34-a5e4-fbabd68492b3.yaml
+++ b/geolexica-v2/fee1aab8-9ed8-5e34-a5e4-fbabd68492b3.yaml
@@ -7,7 +7,6 @@ id: fee1aab8-9ed8-5e34-a5e4-fbabd68492b3
 
 ---
 data:
-  definition: []
   examples: []
   id: '16'
   notes: []

--- a/geolexica-v2/ffb2103d-5534-56c3-8adb-cfc26df264e0.yaml
+++ b/geolexica-v2/ffb2103d-5534-56c3-8adb-cfc26df264e0.yaml
@@ -7,7 +7,6 @@ id: ffb2103d-5534-56c3-8adb-cfc26df264e0
 
 ---
 data:
-  definition: []
   examples: []
   id: '287'
   notes: []

--- a/register.yaml
+++ b/register.yaml
@@ -7,11 +7,11 @@ uri: "https://osgeo.geolexica.org"
 
 owner:
   entity:
-  	name: OSGeo
+    name: OSGeo
 
 manager:
   entity:
-  	name: OSGeo Lexicon Committee
+    name: OSGeo Lexicon Committee
 
 subregisters:
   eng:


### PR DESCRIPTION
- Remove empty `definition: []` arrays from 259 concept files
- Add `glossarist validate` step to build.yml
- Switch `publish-gcr.yml` from vocabulary-browser (Node.js) to glossarist Ruby gem
- All 444 concepts now pass `glossarist validate .` with 0 errors