### PR TITLE
Migrate to glossarist gem with dual GCR publishing

### DIFF
--- a/.github/workflows/publish-gcr.yml
+++ b/.github/workflows/publish-gcr.yml
@@ -2,8 +2,13 @@ name: publish-gcr
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version (e.g. 1.0.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,30 +19,52 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout vocabulary-browser
-        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
-          repository: glossarist/vocabulary-browser
-          ref: main
-          path: vocabulary-browser
+          ruby-version: '3.2'
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: vocabulary-browser/package-lock.json
+      - run: gem install glossarist
 
-      - run: npm ci
-        working-directory: vocabulary-browser
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION="${{ inputs.version }}"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Build GCR package
-        run: node scripts/package-dataset.mjs "$GITHUB_WORKSPACE" --id osgeo -o "$GITHUB_WORKSPACE/../osgeo.gcr"
-        working-directory: vocabulary-browser
+      - name: Build standard GCR package
+        run: |
+          glossarist package . -o "osgeo-${{ steps.version.outputs.version }}.gcr" \
+            --shortname osgeo \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "OSGeo Lexicon" \
+            --owner "OSGeo"
 
-      - name: Update gcr-latest release
+      - name: Build full GCR package (with formats)
+        run: |
+          glossarist package . -o "osgeo-${{ steps.version.outputs.version }}-full.gcr" \
+            --shortname osgeo \
+            --version "${{ steps.version.outputs.version }}" \
+            --title "OSGeo Lexicon" \
+            --owner "OSGeo" \
+            --compiled-formats tbx,jsonld,turtle,jsonl
+
+      - name: Create unversioned aliases
+        run: |
+          cp "osgeo-${{ steps.version.outputs.version }}.gcr" osgeo.gcr
+          cp "osgeo-${{ steps.version.outputs.version }}-full.gcr" osgeo-full.gcr
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: gcr-latest
-          name: "GCR Package (latest)"
-          body: "Auto-generated GCR package with harmonized concepts. Updated on push to main."
-          files: ../osgeo.gcr
+          tag_name: v${{ steps.version.outputs.version }}
+          name: "GCR Package v${{ steps.version.outputs.version }}"
+          body: "Auto-generated GCR package containing OSGeo concepts."
+          files: |
+            osgeo-${{ steps.version.outputs.version }}.gcr
+            osgeo.gcr
+            osgeo-${{ steps.version.outputs.version }}-full.gcr
+            osgeo-full.gcr


### PR DESCRIPTION
## Changes
- Replace vocabulary-browser package-dataset.mjs with glossarist CLI
- Build both standard and full GCR (with compiled formats: TBX, JSON-LD, Turtle, JSONL)
- Migrate from push-to-main/gcr-latest to tag-based versioned releases
- Publish 4 assets per release: standard + full, versioned + unversioned

Depends on glossarist gem with --compiled-formats support.